### PR TITLE
Refactor manifest classes into separate files

### DIFF
--- a/Editor/Manifest/BackupManifest.cs
+++ b/Editor/Manifest/BackupManifest.cs
@@ -1,0 +1,16 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+
+namespace AvatarSmartBackup
+{
+    [Serializable]
+    public class BackupManifest
+    {
+        public string projectName;
+        public string unityVersion;
+        public string createdUtc;
+        public List<ManifestEntry> entries = new List<ManifestEntry>();
+    }
+}
+#endif

--- a/Editor/Manifest/ManifestEntry.cs
+++ b/Editor/Manifest/ManifestEntry.cs
@@ -1,0 +1,16 @@
+#if UNITY_EDITOR
+using System;
+
+namespace AvatarSmartBackup
+{
+    [Serializable]
+    public class ManifestEntry
+    {
+        public string guid;
+        public string relPath;  // Assets/...
+        public string md5;
+        public long size;
+        public long lastWriteUtcTicks;
+    }
+}
+#endif

--- a/Editor/SmartBackups.cs
+++ b/Editor/SmartBackups.cs
@@ -26,25 +26,6 @@ namespace AvatarSmartBackup
         OnPlay    // take a snapshot when entering Play Mode
     }
 
-    [Serializable]
-    public class ManifestEntry
-    {
-        public string guid;
-        public string relPath;  // Assets/...
-        public string md5;
-        public long size;
-        public long lastWriteUtcTicks;
-    }
-
-    [Serializable]
-    public class BackupManifest
-    {
-        public string projectName;
-        public string unityVersion;
-        public string createdUtc;
-        public List<ManifestEntry> entries = new List<ManifestEntry>();
-    }
-
     internal interface IBackupCollector { IEnumerable<string> CollectAbsolutePaths(BackupSettings s); }
     // === Collectors (come prima) ===
     internal class VRCAssetsCollector : IBackupCollector


### PR DESCRIPTION
## Summary
- move `ManifestEntry` and `BackupManifest` into new `Editor/Manifest` folder
- tidy `SmartBackups` by removing inline manifest class definitions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f2cc18288322862ca21c7cfd0173