### PR TITLE
Run .NET backup settings tests on tag workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,25 @@
+name: unity-plugin-tests
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  test:
+    name: Run editor utility tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj
+
+      - name: Run unit tests
+        run: dotnet test tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.meta
+/tests/**/bin/
+/tests/**/obj/

--- a/tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj
+++ b/tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);UNITY_EDITOR</DefineConstants>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Editor/Settings/BackupSettings.cs" Link="AvatarSmartBackup/BackupSettings.cs" />
+    <Compile Include="../../Editor/Settings/ZipPolicy.cs" Link="AvatarSmartBackup/ZipPolicy.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/AvatarSmartBackups.Tests/BackupSettingsTests.cs
+++ b/tests/AvatarSmartBackups.Tests/BackupSettingsTests.cs
@@ -1,0 +1,105 @@
+using AvatarSmartBackup;
+
+namespace AvatarSmartBackups.Tests;
+
+public class BackupSettingsTests
+{
+    [Fact]
+    public void EnsureVersioningDefaults_ResetsInvalidPolicy()
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = (VersioningPolicy)999,
+            manualCheckpointFrequency = 0,
+            forceFullCheckpointEveryN = 0
+        };
+
+        settings.EnsureVersioningDefaults();
+
+        Assert.Equal(VersioningPolicy.Balanced, settings.versioningPolicy);
+        Assert.Equal(5, settings.manualCheckpointFrequency);
+    }
+
+    [Fact]
+    public void EnsureVersioningDefaults_PromotesBalancedWhenForceFullEnabled()
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = VersioningPolicy.Balanced,
+            manualCheckpointFrequency = 0,
+            forceFullCheckpointEveryN = 4
+        };
+
+        settings.EnsureVersioningDefaults();
+
+        Assert.Equal(VersioningPolicy.Manual, settings.versioningPolicy);
+        Assert.Equal(4, settings.manualCheckpointFrequency);
+    }
+
+    [Fact]
+    public void EnsureVersioningDefaults_ManualPolicyWithLowFrequency_UsesDefaultPreset()
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = VersioningPolicy.Manual,
+            manualCheckpointFrequency = 0,
+            forceFullCheckpointEveryN = 0
+        };
+
+        settings.EnsureVersioningDefaults();
+
+        Assert.Equal(VersioningPolicy.Manual, settings.versioningPolicy);
+        Assert.Equal(5, settings.manualCheckpointFrequency);
+    }
+
+    [Fact]
+    public void EnsureVersioningDefaults_ManualPolicyWithLegacyForceFull_ClampsToMinimum()
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = VersioningPolicy.Manual,
+            manualCheckpointFrequency = 0,
+            forceFullCheckpointEveryN = 2
+        };
+
+        settings.EnsureVersioningDefaults();
+
+        Assert.Equal(VersioningPolicy.Manual, settings.versioningPolicy);
+        Assert.Equal(3, settings.manualCheckpointFrequency);
+    }
+
+    [Theory]
+    [InlineData(VersioningPolicy.Balanced, 0, 0)]
+    [InlineData(VersioningPolicy.Frequent, 0, 3)]
+    [InlineData(VersioningPolicy.Manual, 7, 7)]
+    [InlineData(VersioningPolicy.Manual, 0, 1)]
+    public void GetCheckpointInterval_ReturnsExpectedValues(VersioningPolicy policy, int manualFrequency, int expected)
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = policy,
+            manualCheckpointFrequency = manualFrequency
+        };
+
+        var interval = settings.GetCheckpointInterval();
+
+        Assert.Equal(expected, interval);
+    }
+
+    [Theory]
+    [InlineData(VersioningPolicy.Balanced, 0, 0)]
+    [InlineData(VersioningPolicy.Frequent, 0, 3)]
+    [InlineData(VersioningPolicy.Manual, 5, 5)]
+    public void SyncLegacyCheckpointInterval_AlignsWithInterval(VersioningPolicy policy, int manualFrequency, int expected)
+    {
+        var settings = new BackupSettings
+        {
+            versioningPolicy = policy,
+            manualCheckpointFrequency = manualFrequency
+        };
+
+        settings.SyncLegacyCheckpointInterval();
+
+        Assert.Equal(expected, settings.forceFullCheckpointEveryN);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the tag-triggered workflow with a .NET test job for manual dispatch or tag pushes
- add an xUnit test project that exercises the backup settings logic behind UNITY_EDITOR guards
- ignore generated test build artifacts so only sources are tracked

## Testing
- dotnet test tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj --configuration Release

------
https://chatgpt.com/codex/tasks/task_e_68cbe15bfc748322a41f4756ddec9a9d