### PR TITLE
Improve backup integrity checks and version storage safety

### DIFF
--- a/Editor/Backup/BackupManager.cs
+++ b/Editor/Backup/BackupManager.cs
@@ -200,6 +200,47 @@ namespace AvatarSmartBackup
             FileUtilEx.AtomicReplace(tmp, ManifestPath);
         }
 
+        static void RefreshHashesFromCurrent(List<FilePlanItem> files)
+        {
+            if (files == null || files.Count == 0)
+                return;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in files)
+            {
+                if (item?.ManifestEntry == null)
+                    continue;
+
+                if (!item.NeedsCopy && !string.IsNullOrEmpty(item.ManifestEntry.md5))
+                    continue;
+
+                string destination = item.DestinationPath;
+                if (string.IsNullOrEmpty(destination))
+                    continue;
+
+                if (!seen.Add(destination))
+                    continue;
+
+                try
+                {
+                    if (!File.Exists(destination))
+                    {
+                        Log.Warn($"Hash refresh skipped (missing file): {item.ManifestEntry.relPath}");
+                        item.ManifestEntry.md5 = string.Empty;
+                        continue;
+                    }
+
+                    string computed = FileUtilEx.MD5Of(destination);
+                    if (!string.IsNullOrEmpty(computed))
+                        item.ManifestEntry.md5 = computed;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"Failed to refresh hash for {item.ManifestEntry.relPath}: {ex.Message}");
+                }
+            }
+        }
+
         // Removed legacy manifest_v2 support
 
         static void SaveOpenScenesIfDirty()
@@ -665,6 +706,7 @@ namespace AvatarSmartBackup
 
                 // 4) Manifest + prune (nevern thread)
                 PruneRemoved(man);
+                RefreshHashesFromCurrent(plannedFiles);
                 WriteManifest(man);
                 File.WriteAllText(Path.Combine(CurrentDir, "backup.ok"), DateTime.UtcNow.ToString("o"));
 

--- a/Editor/Versioning/FileBasedVersionManager.cs
+++ b/Editor/Versioning/FileBasedVersionManager.cs
@@ -30,11 +30,18 @@ namespace AvatarSmartBackup
 
         private void EnsureIndexFile()
         {
-            if (!File.Exists(_indexFile))
+            if (File.Exists(_indexFile))
+                return;
+
+            string backupIndex = _indexFile + ".bak";
+            if (File.Exists(backupIndex))
             {
-                var index = new VersionIndex { versions = new List<VersionInfo>(), schemaVersion = VersionIndex.CurrentSchemaVersion };
-                SaveIndex(index);
+                Debug.LogWarning($"[ASB] Versions index missing but a backup exists at {backupIndex}. Not recreating automatically.");
+                return;
             }
+
+            var index = new VersionIndex { versions = new List<VersionInfo>(), schemaVersion = VersionIndex.CurrentSchemaVersion };
+            SaveIndex(index);
         }
 
         private VersionIndex LoadIndex()
@@ -42,7 +49,12 @@ namespace AvatarSmartBackup
             try
             {
                 if (!File.Exists(_indexFile))
+                {
+                    string backupPath = _indexFile + ".bak";
+                    if (File.Exists(backupPath))
+                        throw new InvalidOperationException($"Versions index missing. A backup copy exists at {backupPath}. Restore it manually to proceed.");
                     return new VersionIndex { versions = new List<VersionInfo>(), schemaVersion = VersionIndex.CurrentSchemaVersion };
+                }
 
                 string json = File.ReadAllText(_indexFile);
                 var index = JsonUtility.FromJson<VersionIndex>(json) ?? new VersionIndex { versions = new List<VersionInfo>() };
@@ -54,8 +66,10 @@ namespace AvatarSmartBackup
             }
             catch (Exception ex)
             {
-                Debug.LogWarning($"[ASB] Failed to load versions index: {ex.Message}");
-                return new VersionIndex { versions = new List<VersionInfo>(), schemaVersion = VersionIndex.CurrentSchemaVersion };
+                TryBackupCorruptIndex();
+                string message = $"[ASB] Failed to load versions index: {ex.Message}. The corrupted file was moved to .bak.";
+                Debug.LogError(message);
+                throw new InvalidOperationException("Versions index could not be loaded. Please inspect the backup copy before continuing.", ex);
             }
         }
 
@@ -67,12 +81,35 @@ namespace AvatarSmartBackup
                 string json = JsonUtility.ToJson(index, true);
                 string tmp = _indexFile + ".tmp";
                 File.WriteAllText(tmp, json);
-                if (File.Exists(_indexFile)) File.Delete(_indexFile);
-                File.Move(tmp, _indexFile);
+                FileUtilEx.AtomicReplace(tmp, _indexFile);
             }
             catch (Exception ex)
             {
                 Debug.LogError($"[ASB] Failed to save versions index: {ex.Message}");
+            }
+        }
+
+        private void TryBackupCorruptIndex()
+        {
+            try
+            {
+                if (!File.Exists(_indexFile)) return;
+
+                string baseBackup = _indexFile + ".bak";
+                string backupPath = baseBackup;
+                int counter = 0;
+                while (File.Exists(backupPath))
+                {
+                    counter++;
+                    backupPath = _indexFile + $".bak{counter}";
+                }
+
+                File.Move(_indexFile, backupPath);
+                Debug.LogWarning($"[ASB] Versions index moved to {backupPath} due to read failure.");
+            }
+            catch (Exception moveEx)
+            {
+                Debug.LogWarning($"[ASB] Failed to move corrupt versions index: {moveEx.Message}");
             }
         }
 
@@ -198,8 +235,10 @@ namespace AvatarSmartBackup
                     CopyDeltaFiles(currentBackupPath, versionDir, diff);
                 }
 
-                File.Copy(manifestPath, Path.Combine(versionDir, ManifestFileName), true);
-                File.WriteAllText(Path.Combine(versionDir, SnapshotMarkerName), "ok");
+                string manifestDestination = Path.Combine(versionDir, ManifestFileName);
+                string manifestTmp = manifestDestination + ".tmp";
+                File.Copy(manifestPath, manifestTmp, true);
+                FileUtilEx.AtomicReplace(manifestTmp, manifestDestination);
 
                 int parentId = latest?.id ?? 0;
                 int checkpointId = isCheckpoint ? nextId : ResolveCheckpointId(latest);
@@ -207,7 +246,14 @@ namespace AvatarSmartBackup
 
                 var deltaMetadata = BuildDeltaMetadata(diff, nextId, isCheckpoint, parentId, checkpointId);
                 string deltaPath = Path.Combine(versionDir, DeltaFileName);
-                File.WriteAllText(deltaPath, JsonUtility.ToJson(deltaMetadata, true));
+                string deltaTmp = deltaPath + ".tmp";
+                File.WriteAllText(deltaTmp, JsonUtility.ToJson(deltaMetadata, true));
+                FileUtilEx.AtomicReplace(deltaTmp, deltaPath);
+
+                string markerPath = Path.Combine(versionDir, SnapshotMarkerName);
+                string markerTmp = markerPath + ".tmp";
+                File.WriteAllText(markerTmp, "ok");
+                FileUtilEx.AtomicReplace(markerTmp, markerPath);
 
                 long totalSize = manifest.entries.Sum(e => Math.Max(0, e.size));
                 int totalCount = manifest.entries.Count;
@@ -638,6 +684,38 @@ namespace AvatarSmartBackup
         {
             var index = LoadIndex();
             return index.versions.Count;
+        }
+
+        public void MarkVersionCorrupt(int id, bool markIncomplete, string reason = null)
+        {
+            try
+            {
+                var index = LoadIndex();
+                var version = index.versions?.FirstOrDefault(v => v.id == id);
+                if (version == null) return;
+
+                bool changed = false;
+                if (!version.corrupt)
+                {
+                    version.corrupt = true;
+                    changed = true;
+                }
+                if (markIncomplete && !version.incomplete)
+                {
+                    version.incomplete = true;
+                    changed = true;
+                }
+
+                if (changed)
+                    SaveIndex(index);
+
+                if (!string.IsNullOrEmpty(reason))
+                    Debug.LogError($"[ASB] Version #{id} marked as corrupt: {reason}");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[ASB] Failed to mark version #{id} as corrupt: {ex.Message}");
+            }
         }
 
         public VersionIndexRebuildReport RebuildIndex(bool applyChanges)

--- a/Editor/Versioning/VersionRestoreService.cs
+++ b/Editor/Versioning/VersionRestoreService.cs
@@ -72,13 +72,16 @@ namespace AvatarSmartBackup
 
             CopyDirectory(checkpointDir, rebuildDir);
 
-            bool missingDelta = false;
-
             for (int i = 1; i < chain.Count; i++)
             {
                 var current = chain[i];
                 string versionDir = Path.Combine(FileUtilEx.BackupRoot, "Versions", $"v{current.id:D3}");
                 string deltaRoot = Path.Combine(versionDir, "delta");
+                string deltaMetadataPath = Path.Combine(versionDir, "delta.json");
+                if (!File.Exists(deltaMetadataPath))
+                {
+                    FailDeltaRebuild(vm, target, current, $"Delta metadata missing for version #{current.id}.");
+                }
                 var delta = LoadDeltaMetadata(versionDir);
 
                 foreach (var entry in delta.changedEntries)
@@ -86,9 +89,7 @@ namespace AvatarSmartBackup
                     string src = Path.Combine(deltaRoot, entry.relPath.Replace('/', Path.DirectorySeparatorChar));
                     if (!File.Exists(src))
                     {
-                        Debug.LogWarning($"[ASB] Delta file missing for version #{current.id}: {entry.relPath}");
-                        missingDelta = true;
-                        continue;
+                        FailDeltaRebuild(vm, target, current, $"Delta file missing for version #{current.id}: {entry.relPath}");
                     }
                     string dst = Path.Combine(rebuildDir, entry.relPath.Replace('/', Path.DirectorySeparatorChar));
                     Directory.CreateDirectory(Path.GetDirectoryName(dst));
@@ -116,12 +117,7 @@ namespace AvatarSmartBackup
                 }
             }
 
-            if (missingDelta)
-            {
-                _lastWarning = $"Alcuni delta mancanti nella versione #{target.id}; il contenuto potrebbe essere incompleto.";
-                Log.Warn(_lastWarning);
-                Debug.LogWarning($"[ASB] {_lastWarning}");
-            }
+            ValidateRebuiltSnapshot(vm, target, rebuildDir);
         }
 
         static List<VersionInfo> BuildChain(FileBasedVersionManager vm, VersionInfo target)
@@ -195,6 +191,91 @@ namespace AvatarSmartBackup
             var segments = relativePath.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
             if (segments.Length == 0) return false;
             return string.Equals(segments[0], "delta", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static void FailDeltaRebuild(FileBasedVersionManager vm, VersionInfo target, VersionInfo failingVersion, string reason)
+        {
+            _lastWarning = reason;
+            vm?.MarkVersionCorrupt(failingVersion.id, markIncomplete: true, reason: reason);
+            if (target != null && target.id != failingVersion.id)
+                vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+            Log.Error(reason);
+            Debug.LogError($"[ASB] {reason}");
+            throw new InvalidOperationException(reason);
+        }
+
+        static void ValidateRebuiltSnapshot(FileBasedVersionManager vm, VersionInfo target, string rebuildDir)
+        {
+            if (target == null)
+                return;
+
+            string versionDir = Path.Combine(FileUtilEx.BackupRoot, "Versions", $"v{target.id:D3}");
+            string manifestPath = Path.Combine(versionDir, "manifest.json");
+            BackupManifest manifest = null;
+            try
+            {
+                if (!File.Exists(manifestPath))
+                    throw new FileNotFoundException("Manifest not found", manifestPath);
+                string json = File.ReadAllText(manifestPath);
+                manifest = JsonUtility.FromJson<BackupManifest>(json);
+            }
+            catch (Exception ex)
+            {
+                string reason = $"Manifest unavailable for version #{target.id}: {ex.Message}";
+                vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+                Log.Error(reason);
+                Debug.LogError($"[ASB] {reason}");
+                throw new InvalidOperationException(reason, ex);
+            }
+
+            if (manifest?.entries == null)
+            {
+                string reason = $"Manifest for version #{target.id} is empty or invalid.";
+                vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+                Log.Error(reason);
+                Debug.LogError($"[ASB] {reason}");
+                throw new InvalidOperationException(reason);
+            }
+
+            foreach (var entry in manifest.entries)
+            {
+                if (entry == null || string.IsNullOrEmpty(entry.relPath))
+                    continue;
+
+                string dst = Path.Combine(rebuildDir, entry.relPath.Replace('/', Path.DirectorySeparatorChar));
+                if (!File.Exists(dst))
+                {
+                    string reason = $"Missing file {entry.relPath} while rebuilding version #{target.id}.";
+                    vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+                    Log.Error(reason);
+                    Debug.LogError($"[ASB] {reason}");
+                    throw new InvalidOperationException(reason);
+                }
+
+                if (string.IsNullOrEmpty(entry.md5))
+                    continue;
+
+                try
+                {
+                    string computed = FileUtilEx.MD5Of(dst);
+                    if (!string.Equals(computed, entry.md5, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string reason = $"Hash mismatch for {entry.relPath} while rebuilding version #{target.id}.";
+                        vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+                        Log.Error(reason);
+                        Debug.LogError($"[ASB] {reason}");
+                        throw new InvalidOperationException(reason);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    string reason = $"Failed to verify hash for {entry.relPath} in version #{target.id}: {ex.Message}";
+                    vm?.MarkVersionCorrupt(target.id, markIncomplete: true, reason: reason);
+                    Log.Error(reason);
+                    Debug.LogError($"[ASB] {reason}");
+                    throw new InvalidOperationException(reason, ex);
+                }
+            }
         }
 
         static string MakeRelative(string path, string root)


### PR DESCRIPTION
## Summary
- recompute manifest hashes from the stored backup copy so metadata reflects the saved files
- harden version index management with atomic writes and corruption handling instead of silent resets
- fail snapshot rebuilds when delta data or hashes are invalid and mark affected versions as corrupt

## Testing
- not run (Unity plugin tests prohibited)

------
