### PR TITLE
Handle nullable inputs across backup utilities

### DIFF
--- a/Editor/Backup/FileScanner.cs
+++ b/Editor/Backup/FileScanner.cs
@@ -26,7 +26,7 @@ namespace AvatarSmartBackup
 
     internal interface IFileScanner
     {
-        IReadOnlyList<FileScanResult> Scan(BackupSettings settings, IEnumerable<string> dirtyPaths = null);
+        IReadOnlyList<FileScanResult> Scan(BackupSettings settings, IEnumerable<string>? dirtyPaths = null);
     }
 
     internal sealed class FileScanner : IFileScanner
@@ -41,7 +41,7 @@ namespace AvatarSmartBackup
             "Expression Parameters.asset"
         };
 
-        public IReadOnlyList<FileScanResult> Scan(BackupSettings settings, IEnumerable<string> dirtyPaths = null)
+        public IReadOnlyList<FileScanResult> Scan(BackupSettings settings, IEnumerable<string>? dirtyPaths = null)
         {
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
@@ -180,7 +180,7 @@ namespace AvatarSmartBackup
             return set;
         }
 
-        static List<string> NormalizeDirtyPaths(IEnumerable<string> dirtyPaths, string assetsRoot)
+        static List<string> NormalizeDirtyPaths(IEnumerable<string>? dirtyPaths, string assetsRoot)
         {
             var result = new List<string>();
             if (dirtyPaths == null) return result;
@@ -199,22 +199,22 @@ namespace AvatarSmartBackup
                 {
                     foreach (var file in EnumerateAssets(abs))
                     {
-                        string normalized = NormalizeCandidate(file);
-                        if (normalized != null && seen.Add(normalized))
+                        var normalized = NormalizeCandidate(file);
+                        if (!string.IsNullOrEmpty(normalized) && seen.Add(normalized))
                             result.Add(normalized);
                     }
                 }
                 else if (File.Exists(abs))
                 {
-                    string normalized = NormalizeCandidate(abs);
-                    if (normalized != null && seen.Add(normalized))
+                    var normalized = NormalizeCandidate(abs);
+                    if (!string.IsNullOrEmpty(normalized) && seen.Add(normalized))
                         result.Add(normalized);
                 }
             }
             return result;
         }
 
-        static string NormalizeCandidate(string absPath)
+        static string? NormalizeCandidate(string? absPath)
         {
             if (string.IsNullOrEmpty(absPath)) return null;
             if (absPath.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))

--- a/Editor/Localization/L.cs
+++ b/Editor/Localization/L.cs
@@ -23,7 +23,7 @@ namespace AvatarSmartBackup.Localization
         readonly Dictionary<string, string> _en;
         readonly Dictionary<string, string> _it;
 
-        public DictionaryLocalizationSource(Dictionary<string, string> en, Dictionary<string, string> it = null)
+        public DictionaryLocalizationSource(Dictionary<string, string>? en, Dictionary<string, string>? it = null)
         {
             _en = en ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             _it = it ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -103,12 +103,12 @@ namespace AvatarSmartBackup.Localization
             AddSource(new DictionaryLocalizationSource(en, it));
         }
 
-        public static string T(string key, string fallback = null, params object[] args)
+        public static string T(string key, string? fallback = null, params object[]? args)
         {
             if (string.IsNullOrEmpty(key)) return fallback ?? string.Empty;
             EnsureInitialized();
 
-            string text = null;
+            string? text = null;
             foreach (var s in _sources)
             {
                 if (s.TryGet(key, Current, out text)) break;
@@ -126,15 +126,15 @@ namespace AvatarSmartBackup.Localization
                 try { text = string.Format(text, args); }
                 catch (FormatException) { /* ignore formatting errors */ }
             }
-            return text;
+            return text ?? string.Empty;
         }
 
-        public static GUIContent C(string key, string fallback = null)
+        public static GUIContent C(string key, string? fallback = null)
         {
             return new GUIContent(T(key, fallback));
         }
 
-        public static GUIContent C(string key, string fallback, string tooltipKey, string tooltipFallback = null)
+        public static GUIContent C(string key, string? fallback, string tooltipKey, string? tooltipFallback = null)
         {
             return new GUIContent(T(key, fallback), T(tooltipKey, tooltipFallback));
         }

--- a/Editor/Utils/ExceptionHandler.cs
+++ b/Editor/Utils/ExceptionHandler.cs
@@ -24,7 +24,7 @@ namespace AvatarSmartBackup
             }
             catch (Exception ex)
             {
-                HandleException(ex, operationName, userFriendlyMessage!);
+                HandleException(ex, operationName, userFriendlyMessage);
             }
         }
 
@@ -32,7 +32,7 @@ namespace AvatarSmartBackup
         /// Execute a function with automatic exception handling and logging
         /// Returns default(T) if an exception occurs
         /// </summary>
-        public static T SafeExecute<T>(Func<T> func, string operationName, string? userFriendlyMessage = null, T defaultValue = default!)
+        public static T SafeExecute<T>(Func<T> func, string operationName, string? userFriendlyMessage = null, T defaultValue = default)
         {
             try
             {
@@ -40,8 +40,8 @@ namespace AvatarSmartBackup
             }
             catch (Exception ex)
             {
-                HandleException(ex, operationName, userFriendlyMessage!);
-                return defaultValue!;
+                HandleException(ex, operationName, userFriendlyMessage);
+                return defaultValue;
             }
         }
 
@@ -56,7 +56,7 @@ namespace AvatarSmartBackup
             }
             catch (Exception ex)
             {
-                HandleException(ex, operationName, userFriendlyMessage!);
+                HandleException(ex, operationName, userFriendlyMessage);
             }
         }
 
@@ -64,7 +64,7 @@ namespace AvatarSmartBackup
         /// Execute an async function with automatic exception handling and logging
         /// Returns default(T) if an exception occurs
         /// </summary>
-        public static async Task<T> SafeExecuteAsync<T>(Func<Task<T>> asyncFunc, string operationName, string? userFriendlyMessage = null, T defaultValue = default!)
+        public static async Task<T> SafeExecuteAsync<T>(Func<Task<T>> asyncFunc, string operationName, string? userFriendlyMessage = null, T defaultValue = default)
         {
             try
             {
@@ -72,22 +72,22 @@ namespace AvatarSmartBackup
             }
             catch (Exception ex)
             {
-                HandleException(ex, operationName, userFriendlyMessage!);
-                return defaultValue!;
+                HandleException(ex, operationName, userFriendlyMessage);
+                return defaultValue;
             }
         }
 
         /// <summary>
         /// Central exception handling logic
         /// </summary>
-        private static void HandleException(Exception ex, string operationName, string userFriendlyMessage)
+        private static void HandleException(Exception ex, string operationName, string? userFriendlyMessage)
         {
             // Detailed technical message for log file
             string detailedMessage = $"Operation '{operationName}' failed: {ex.Message}";
-            
+
             // User-friendly message for console (fallback to operation name if not provided)
             string consoleMessage = userFriendlyMessage ?? $"Operation failed: {operationName}";
-            
+
             // Add suggestion to check log file
             if (!string.IsNullOrEmpty(userFriendlyMessage))
                 consoleMessage += " (see log file for details)";

--- a/Editor/Utils/FileUtilEx.cs
+++ b/Editor/Utils/FileUtilEx.cs
@@ -9,11 +9,31 @@ namespace AvatarSmartBackup
 {
     internal static class FileUtilEx
     {
-        public static string ProjectRoot => Directory.GetParent(Application.dataPath).FullName;
+        public static string ProjectRoot
+        {
+            get
+            {
+                var parent = Directory.GetParent(Application.dataPath);
+                if (parent == null)
+                    throw new InvalidOperationException("Unable to determine Unity project root directory.");
+                return parent.FullName;
+            }
+        }
         public static string ProjectName => new DirectoryInfo(ProjectRoot).Name;
         public static string BackupRoot => Path.Combine(ProjectRoot, $"{Sanitize(ProjectName)} Backups");
-        public static string Sanitize(string s) { foreach (var c in Path.GetInvalidFileNameChars()) s = s.Replace(c, '_'); return s.Trim(); }
-        public static string MakeRelToProject(string abs) { var r = ProjectRoot.Replace('\\', '/'); var p = abs.Replace('\\', '/'); return p.StartsWith(r + "/") ? p.Substring(r.Length + 1) : p; }
+        public static string Sanitize(string? s)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            foreach (var c in Path.GetInvalidFileNameChars()) s = s.Replace(c, '_');
+            return s.Trim();
+        }
+        public static string MakeRelToProject(string? abs)
+        {
+            if (string.IsNullOrEmpty(abs)) return string.Empty;
+            var r = ProjectRoot.Replace('\\', '/');
+            var p = abs.Replace('\\', '/');
+            return p.StartsWith(r + "/") ? p.Substring(r.Length + 1) : p;
+        }
         public static string AssetToAbs(string ap) => Path.Combine(ProjectRoot, ap);
 
         public static string MD5Of(string file)
@@ -58,8 +78,9 @@ namespace AvatarSmartBackup
             return sb.ToString();
         }
 
-        public static string TryReadGuidFromMeta(string assetAbs)
+        public static string TryReadGuidFromMeta(string? assetAbs)
         {
+            if (string.IsNullOrEmpty(assetAbs)) return null;
             try
             {
                 string meta = assetAbs + ".meta";
@@ -79,7 +100,10 @@ namespace AvatarSmartBackup
 
         public static void AtomicReplace(string tmp, string finalPath)
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(finalPath));
+            var finalDir = Path.GetDirectoryName(finalPath);
+            if (string.IsNullOrEmpty(finalDir))
+                throw new InvalidOperationException("Invalid destination path for atomic replace.");
+            Directory.CreateDirectory(finalDir);
             if (File.Exists(finalPath))
             {
                 try { File.Replace(tmp, finalPath, null, true); }

--- a/Editor/Utils/Log.cs
+++ b/Editor/Utils/Log.cs
@@ -24,21 +24,21 @@ namespace AvatarSmartBackup
             Error = 3
         }
 
-        static void WriteToFile(Level level, string msg, Exception ex = null)
+        static void WriteToFile(Level level, string? msg, Exception? ex = null)
         {
             try
             {
                 Directory.CreateDirectory(LogDir);
-                
+
                 // Check if current log file needs rotation
                 if (File.Exists(CurrentLogFile) && new FileInfo(CurrentLogFile).Length > MaxLogSizeBytes)
                 {
                     RotateLogFiles();
                 }
-                
+
                 string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                string line = $"{timestamp} [{level.ToString().ToUpperInvariant()}] {msg}";
-                
+                string line = $"{timestamp} [{level.ToString().ToUpperInvariant()}] {msg ?? string.Empty}";
+
                 if (ex != null)
                 {
                     line += $"{Environment.NewLine}Exception: {ex.GetType().Name}: {ex.Message}";
@@ -91,10 +91,10 @@ namespace AvatarSmartBackup
         }
 
         // Console logging - minimal and user-friendly
-        static void LogToConsole(Level level, string userMessage)
+        static void LogToConsole(Level level, string? userMessage)
         {
-            string consoleMsg = Tag + userMessage;
-            
+            string consoleMsg = Tag + (userMessage ?? string.Empty);
+
             switch (level)
             {
                 case Level.Debug:
@@ -111,36 +111,38 @@ namespace AvatarSmartBackup
         }
 
         // Public API - simplified console messages, detailed file logging
-        public static void Debug(string detailedMsg, string consoleMsg = null)
+        public static void Debug(string detailedMsg, string? consoleMsg = null)
         {
             if (ShouldLogToFile(Level.Debug))
                 WriteToFile(Level.Debug, detailedMsg);
-            
+
             // Only show in console if advanced mode is enabled
             var settings = SafeGetSettings();
             if (settings.DiagnosticsEnabled && !string.IsNullOrEmpty(consoleMsg))
                 LogToConsole(Level.Debug, consoleMsg);
         }
 
-        public static void Info(string detailedMsg, string consoleMsg = null)
+        public static void Info(string detailedMsg, string? consoleMsg = null)
         {
             if (ShouldLogToFile(Level.Info))
                 WriteToFile(Level.Info, detailedMsg);
-            
+
             if (!string.IsNullOrEmpty(consoleMsg))
                 LogToConsole(Level.Info, consoleMsg);
         }
 
-        public static void Warn(string detailedMsg, string consoleMsg = null)
+        public static void Warn(string detailedMsg, string? consoleMsg = null)
         {
-            WriteToFile(Level.Warn, detailedMsg);
-            LogToConsole(Level.Warn, consoleMsg ?? detailedMsg);
+            string safeDetail = detailedMsg ?? string.Empty;
+            WriteToFile(Level.Warn, safeDetail);
+            LogToConsole(Level.Warn, consoleMsg ?? safeDetail);
         }
 
-        public static void Error(string detailedMsg, string consoleMsg = null, Exception ex = null)
+        public static void Error(string detailedMsg, string? consoleMsg = null, Exception? ex = null)
         {
-            WriteToFile(Level.Error, detailedMsg, ex);
-            LogToConsole(Level.Error, consoleMsg ?? detailedMsg);
+            string safeDetail = detailedMsg ?? string.Empty;
+            WriteToFile(Level.Error, safeDetail, ex);
+            LogToConsole(Level.Error, consoleMsg ?? safeDetail);
         }
 
         // Utility methods
@@ -148,7 +150,7 @@ namespace AvatarSmartBackup
         public static string GetCurrentLogFile() => CurrentLogFile;
 
         // Thread-safe cached access alle settings per logging
-        static BackupSettings _cachedSettings;
+        static BackupSettings? _cachedSettings;
         static DateTime _lastSettingsFetch;
         static readonly TimeSpan SettingsCacheLifetime = TimeSpan.FromSeconds(5);
         static readonly object _settingsLock = new object();
@@ -163,7 +165,7 @@ namespace AvatarSmartBackup
                         return _cachedSettings;
                 }
                 // Eseguiamo la fetch sul main thread per sicurezza
-                var s = MainThread.InvokeBlocking(() => BackupManager.LoadSettings());
+                var s = MainThread.InvokeBlocking(() => BackupManager.LoadSettings()) ?? new BackupSettings();
                 lock (_settingsLock)
                 {
                     _cachedSettings = s;

--- a/Editor/Utils/MainThread.cs
+++ b/Editor/Utils/MainThread.cs
@@ -15,18 +15,24 @@ namespace AvatarSmartBackup
             MainId = Thread.CurrentThread.ManagedThreadId;
         }
 
-        public static void Invoke(Action a)
+        public static void Invoke(Action? action)
         {
-            if (Thread.CurrentThread.ManagedThreadId == MainId) a();
-            else EditorApplication.delayCall += () => a();
+            if (action == null) return;
+            if (Thread.CurrentThread.ManagedThreadId == MainId) action();
+            else EditorApplication.delayCall += () => action();
         }
 
-        public static T InvokeBlocking<T>(Func<T> f)
+        public static T? InvokeBlocking<T>(Func<T>? func)
         {
-            if (Thread.CurrentThread.ManagedThreadId == MainId) return f();
-            T result = default;
+            if (func == null) return default;
+            if (Thread.CurrentThread.ManagedThreadId == MainId) return func();
+            T? result = default;
             var ev = new ManualResetEventSlim();
-            EditorApplication.delayCall += () => { result = f(); ev.Set(); };
+            EditorApplication.delayCall += () =>
+            {
+                result = func();
+                ev.Set();
+            };
             ev.Wait();
             return result;
         }

--- a/Editor/Utils/ProgressUX.cs
+++ b/Editor/Utils/ProgressUX.cs
@@ -29,13 +29,13 @@ namespace AvatarSmartBackup
             _remove = _progressType.GetMethod("Remove", new[] { typeof(int) });
         }
 
-        public static int Start(string title, string desc, bool cancellable, Func<bool> onCancel = null)
+        public static int Start(string title, string desc, bool cancellable, Func<bool>? onCancel = null)
         {
             Ensure();
             if (_progressType == null) return -1;
             try
             {
-                return MainThread.InvokeBlocking(() =>
+                var result = MainThread.InvokeBlocking(() =>
                 {
                     int id;
                     if (_start != null && _start.GetParameters().Length == 3)
@@ -64,15 +64,16 @@ namespace AvatarSmartBackup
                     }
                     return id;
                 });
+                return result ?? -1;
             }
             catch { return -1; }
         }
 
-        public static void Report(int id, float p, string desc)
+        public static void Report(int id, float p, string? desc)
         {
             if (id < 0) return;
             Ensure();
-            try { MainThread.Invoke(() => _report?.Invoke(null, new object[] { id, Mathf.Clamp01(p), desc })); }
+            try { MainThread.Invoke(() => _report?.Invoke(null, new object[] { id, Mathf.Clamp01(p), desc ?? string.Empty })); }
             catch { /* ignore */ }
         }
 

--- a/Editor/Utils/SelectionFilter.cs
+++ b/Editor/Utils/SelectionFilter.cs
@@ -14,7 +14,7 @@ namespace AvatarSmartBackup
             public bool IsDirectory;
         }
 
-        public static List<Rule> BuildRules(BackupSettings settings)
+        public static List<Rule> BuildRules(BackupSettings? settings)
         {
             var result = new List<Rule>();
             if (settings?.trackedRoots == null || settings.trackedRoots.Count == 0)
@@ -39,7 +39,7 @@ namespace AvatarSmartBackup
             return result;
         }
 
-        public static List<string> NormalizeForStorage(IEnumerable<string> entries)
+        public static List<string> NormalizeForStorage(IEnumerable<string>? entries)
         {
             var result = new List<string>();
             if (entries == null) return result;
@@ -54,7 +54,7 @@ namespace AvatarSmartBackup
             return result;
         }
 
-        static string NormalizeRawPath(string raw)
+        static string? NormalizeRawPath(string? raw)
         {
             if (string.IsNullOrWhiteSpace(raw))
                 return null;
@@ -75,7 +75,7 @@ namespace AvatarSmartBackup
             return trimmed;
         }
 
-        public static bool Allows(List<Rule> rules, string relPath)
+        public static bool Allows(List<Rule>? rules, string relPath)
         {
             if (rules == null || rules.Count == 0)
                 return true;

--- a/Editor/Versioning/ContentAddressableStore.cs
+++ b/Editor/Versioning/ContentAddressableStore.cs
@@ -11,7 +11,7 @@ namespace AvatarSmartBackup
         readonly string _root;
         readonly string _stagingRoot;
 
-        public ContentAddressableStore(string storeRoot = null)
+        public ContentAddressableStore(string? storeRoot = null)
         {
             _root = storeRoot ?? Path.Combine(FileUtilEx.BackupRoot, "Store");
             _stagingRoot = Path.Combine(_root, "tmp");
@@ -19,7 +19,7 @@ namespace AvatarSmartBackup
             Directory.CreateDirectory(_stagingRoot);
         }
 
-        public string GetBlobPath(string hash)
+        public string GetBlobPath(string? hash)
         {
             if (string.IsNullOrEmpty(hash) || hash.Length < 6)
                 return string.Empty;
@@ -28,7 +28,7 @@ namespace AvatarSmartBackup
             return Path.Combine(_root, first, second, hash);
         }
 
-        public bool Exists(string hash)
+        public bool Exists(string? hash)
         {
             string path = GetBlobPath(hash);
             return !string.IsNullOrEmpty(path) && File.Exists(path);
@@ -65,7 +65,10 @@ namespace AvatarSmartBackup
                 if (string.IsNullOrEmpty(finalPath))
                     throw new InvalidOperationException("Invalid hash computed for CAS blob.");
 
-                Directory.CreateDirectory(Path.GetDirectoryName(finalPath));
+                var finalDir = Path.GetDirectoryName(finalPath);
+                if (string.IsNullOrEmpty(finalDir))
+                    throw new InvalidOperationException("Invalid final path for CAS blob.");
+                Directory.CreateDirectory(finalDir);
                 if (File.Exists(finalPath))
                 {
                     try { File.Delete(stagingPath); } catch { }
@@ -93,7 +96,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        public bool TryOpenRead(string hash, out FileStream stream)
+        public bool TryOpenRead(string? hash, out FileStream? stream)
         {
             string path = GetBlobPath(hash);
             if (!string.IsNullOrEmpty(path) && File.Exists(path))
@@ -105,7 +108,7 @@ namespace AvatarSmartBackup
             return false;
         }
 
-        static string BytesToHex(byte[] hash)
+        static string BytesToHex(byte[]? hash)
         {
             if (hash == null || hash.Length == 0) return string.Empty;
             char[] chars = new char[hash.Length * 2];


### PR DESCRIPTION
## Summary
- update the backup file scanner to tolerate nullable dirty-path inputs and normalize candidates safely
- treat optional logging/exception parameters as nullable and add fallbacks for console/file output
- propagate nullable handling across localization, progress, selection, threading, CAS, and file utilities, including guarding Directory.GetParent

## Testing
- `dotnet build AvatarSmartBackups/AvatarSmartBackups.Core` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4c7f98c483229f969b2bc4d7fcb7