### PR TITLE
Handle nullable version restore data

### DIFF
--- a/Editor/Backup/BackupManager.cs
+++ b/Editor/Backup/BackupManager.cs
@@ -127,7 +127,8 @@ namespace AvatarSmartBackup
             {
                 var settings = LoadSettings();
                 var normalized = SelectionFilter.NormalizeForStorage(entries);
-                if (normalized.Any(p => p.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
+                var normalizedList = normalized ?? new List<string>();
+                if (normalizedList.Any(p => p.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)))
                 {
                     error = "Script files (.cs) are excluded from backups.";
                     return false;
@@ -138,7 +139,7 @@ namespace AvatarSmartBackup
                 if (frozen)
                 {
                     var existing = new HashSet<string>(settings.trackedRoots ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
-                    foreach (var candidate in normalized)
+                    foreach (var candidate in normalizedList)
                     {
                         if (!existing.Contains(candidate))
                         {
@@ -148,7 +149,7 @@ namespace AvatarSmartBackup
                     }
                 }
 
-                settings.trackedRoots = normalized;
+                settings.trackedRoots = normalizedList;
                 if (lockSelection || hasVersions)
                     settings.selectionLocked = true;
 
@@ -184,7 +185,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        static BackupManifest LoadManifest()
+        static BackupManifest? LoadManifest()
         {
             try
             {

--- a/Editor/Versioning/FileBasedVersionManager.cs
+++ b/Editor/Versioning/FileBasedVersionManager.cs
@@ -208,7 +208,7 @@ namespace AvatarSmartBackup
             return changed;
         }
 
-        public bool CreateVersion(string description, string currentBackupPath, BackupSettings settings = null, bool? forceCheckpoint = null)
+        public bool CreateVersion(string description, string currentBackupPath, BackupSettings? settings = null, bool? forceCheckpoint = null)
         {
             try
             {
@@ -234,7 +234,7 @@ namespace AvatarSmartBackup
 
                 var index = LoadIndex();
                 var latest = GetLatestVersion(index);
-                BackupManifest previousManifest = null;
+                BackupManifest? previousManifest = null;
                 if (latest != null)
                     previousManifest = LoadManifestForVersion(latest.id);
 
@@ -325,10 +325,10 @@ namespace AvatarSmartBackup
             }
         }
 
-        private VersionInfo GetLatestVersion(VersionIndex index)
+        private VersionInfo? GetLatestVersion(VersionIndex index)
         {
             if (index?.versions == null || index.versions.Count == 0) return null;
-            VersionInfo latest = null;
+            VersionInfo? latest = null;
             foreach (var v in index.versions)
             {
                 if (latest == null || v.id > latest.id)
@@ -337,7 +337,7 @@ namespace AvatarSmartBackup
             return latest;
         }
 
-        private BackupManifest LoadManifestForVersion(int versionId)
+        private BackupManifest? LoadManifestForVersion(int versionId)
         {
             try
             {
@@ -355,7 +355,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        private static bool DetermineIfCheckpoint(VersionInfo latest, BackupSettings settings, bool? forceCheckpoint, ManifestDiff diff)
+        private static bool DetermineIfCheckpoint(VersionInfo? latest, BackupSettings? settings, bool? forceCheckpoint, ManifestDiff? diff)
         {
             if (forceCheckpoint.HasValue)
                 return forceCheckpoint.Value;
@@ -373,7 +373,7 @@ namespace AvatarSmartBackup
             if (configured > 0 && latest.incrementalDepth >= configured - 1)
                 return true;
 
-            if (latest.fileCount > 0)
+            if (latest.fileCount > 0 && diff != null)
             {
                 int totalChanges = diff.Added.Count + diff.Modified.Count + diff.Removed.Count;
                 if (totalChanges >= Math.Max(10, latest.fileCount / 2))
@@ -383,7 +383,7 @@ namespace AvatarSmartBackup
             return false;
         }
 
-        private static int ResolveCheckpointId(VersionInfo latest)
+        private static int ResolveCheckpointId(VersionInfo? latest)
         {
             if (latest == null) return 0;
             if (latest.isCheckpoint) return latest.id;
@@ -405,7 +405,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        private static void CopyDeltaFiles(string sourceRoot, string versionRoot, ManifestDiff diff)
+        private static void CopyDeltaFiles(string sourceRoot, string versionRoot, ManifestDiff? diff)
         {
             if (diff == null) return;
             string deltaRoot = Path.Combine(versionRoot, "delta");
@@ -427,7 +427,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        private static ManifestDiff ComputeDiff(BackupManifest previous, BackupManifest current)
+        private static ManifestDiff ComputeDiff(BackupManifest? previous, BackupManifest? current)
         {
             var diff = new ManifestDiff();
             if (current?.entries == null || current.entries.Count == 0)
@@ -487,7 +487,7 @@ namespace AvatarSmartBackup
             return diff;
         }
 
-        private static bool HasChanged(ManifestEntry current, ManifestEntry previous)
+        private static bool HasChanged(ManifestEntry? current, ManifestEntry? previous)
         {
             if (current == null || previous == null) return true;
             if (!string.IsNullOrEmpty(current.md5) && !string.IsNullOrEmpty(previous.md5))
@@ -501,7 +501,7 @@ namespace AvatarSmartBackup
             return false;
         }
 
-        private static VersionDeltaMetadata BuildDeltaMetadata(ManifestDiff diff, int versionId, bool isCheckpoint, int parentId, int checkpointId)
+        private static VersionDeltaMetadata BuildDeltaMetadata(ManifestDiff? diff, int versionId, bool isCheckpoint, int parentId, int checkpointId)
         {
             var metadata = new VersionDeltaMetadata
             {
@@ -535,19 +535,27 @@ namespace AvatarSmartBackup
                     categoryMap[category] = (agg.count + 1, agg.bytes + Math.Max(0, entry.size));
             }
 
-            foreach (var entry in diff.Added) AddChange(entry, true);
-            foreach (var entry in diff.Modified) AddChange(entry, false);
-
-            long removedBytes = 0;
-            foreach (var removed in diff.Removed)
+            if (diff != null)
             {
-                if (removed == null || string.IsNullOrEmpty(removed.relPath)) continue;
-                metadata.removedEntries.Add(removed.relPath);
-                removedBytes += Math.Max(0, removed.size);
+                foreach (var entry in diff.Added) AddChange(entry, true);
+                foreach (var entry in diff.Modified) AddChange(entry, false);
+
+                long removedBytes = 0;
+                foreach (var removed in diff.Removed)
+                {
+                    if (removed == null || string.IsNullOrEmpty(removed.relPath)) continue;
+                    metadata.removedEntries.Add(removed.relPath);
+                    removedBytes += Math.Max(0, removed.size);
+                }
+
+                metadata.removedBytes = removedBytes;
             }
 
+            if (diff == null)
+            {
+                metadata.removedBytes = 0;
+            }
             metadata.changedBytes = changedBytes;
-            metadata.removedBytes = removedBytes;
             metadata.changedFileCount = metadata.changedEntries.Count;
             metadata.removedFileCount = metadata.removedEntries.Count;
 
@@ -644,7 +652,7 @@ namespace AvatarSmartBackup
             return index.versions.OrderByDescending(v => ParseCreated(v)).ToList();
         }
 
-        public VersionInfo GetVersion(int id)
+        public VersionInfo? GetVersion(int id)
         {
             var index = LoadIndex();
             return index.versions.FirstOrDefault(v => v.id == id);
@@ -713,7 +721,7 @@ namespace AvatarSmartBackup
             return index.versions.Count;
         }
 
-        public void MarkVersionCorrupt(int id, bool markIncomplete, string reason = null)
+        public void MarkVersionCorrupt(int id, bool markIncomplete, string? reason = null)
         {
             try
             {

--- a/Editor/Versioning/VersionRestoreService.cs
+++ b/Editor/Versioning/VersionRestoreService.cs
@@ -11,15 +11,15 @@ namespace AvatarSmartBackup
     internal static class VersionRestoreService
     {
         static readonly object RebuildLock = new object();
-        static string _lastWarning;
-        static RestorePreparationResult _lastResult;
+        static string? _lastWarning;
+        static RestorePreparationResult? _lastResult;
 
-        public static string LastWarning => _lastWarning;
-        public static RestorePreparationResult LastResult => _lastResult;
+        public static string? LastWarning => _lastWarning;
+        public static RestorePreparationResult? LastResult => _lastResult;
 
         static string RebuildRoot => Path.Combine(FileUtilEx.ProjectRoot, "Temp", "ASB_Rebuilds");
 
-        public static string PrepareSnapshot(int versionId, bool forceRebuild = false)
+        public static string? PrepareSnapshot(int versionId, bool forceRebuild = false)
         {
             _lastResult = null;
             var result = PrepareSnapshotInternal(versionId, forceRebuild);
@@ -28,7 +28,7 @@ namespace AvatarSmartBackup
             return result?.SnapshotPath;
         }
 
-        static RestorePreparationResult PrepareSnapshotInternal(int versionId, bool forceRebuild)
+        static RestorePreparationResult? PrepareSnapshotInternal(int versionId, bool forceRebuild)
         {
             _lastWarning = null;
             var notices = new List<string>();
@@ -107,7 +107,7 @@ namespace AvatarSmartBackup
             throw new InvalidOperationException($"Restore attempts exceeded for version #{versionId}.");
         }
 
-        static string PrepareSingleVersion(FileBasedVersionManager vm, VersionInfo version, bool forceRebuild, HashSet<int> skipVersions)
+        static string PrepareSingleVersion(FileBasedVersionManager vm, VersionInfo version, bool forceRebuild, HashSet<int>? skipVersions)
         {
             if (version == null)
                 throw new ArgumentNullException(nameof(version));
@@ -151,8 +151,12 @@ namespace AvatarSmartBackup
             return LoadDeltaMetadata(versionDir);
         }
 
-        static void BuildSnapshot(FileBasedVersionManager vm, VersionInfo target, string rebuildDir, HashSet<int> skipVersions = null)
+        static void BuildSnapshot(FileBasedVersionManager vm, VersionInfo target, string rebuildDir, HashSet<int>? skipVersions = null)
         {
+            if (vm == null)
+                throw new ArgumentNullException(nameof(vm));
+            if (target == null)
+                throw new ArgumentNullException(nameof(target));
             var chain = BuildChain(vm, target);
             if (chain.Count == 0)
                 throw new InvalidOperationException("Version chain is empty.");
@@ -220,7 +224,7 @@ namespace AvatarSmartBackup
         static List<VersionInfo> BuildChain(FileBasedVersionManager vm, VersionInfo target)
         {
             var chain = new List<VersionInfo>();
-            var current = target;
+            VersionInfo? current = target;
             int guard = 0;
             while (current != null && guard++ < 256)
             {
@@ -379,7 +383,7 @@ namespace AvatarSmartBackup
             return Uri.UnescapeDataString(ru.MakeRelativeUri(pu).ToString()).Replace('/', Path.DirectorySeparatorChar);
         }
 
-        static VersionInfo FindPreviousValidVersion(FileBasedVersionManager vm, int startId, HashSet<int> exclude)
+        static VersionInfo? FindPreviousValidVersion(FileBasedVersionManager vm, int startId, HashSet<int>? exclude)
         {
             if (vm == null) return null;
             int candidateId = Math.Max(0, startId);

--- a/Editor/Windows/AvatarSmartBackupWindow.cs
+++ b/Editor/Windows/AvatarSmartBackupWindow.cs
@@ -822,7 +822,13 @@ namespace AvatarSmartBackup
             if (info == null) return;
             try
             {
-                string path = VersionRestoreService.PrepareSnapshot(info.id, forceRebuild: true);
+                var path = VersionRestoreService.PrepareSnapshot(info.id, forceRebuild: true);
+                if (string.IsNullOrEmpty(path))
+                {
+                    Log.Warn($"Snapshot rebuild returned no path for version #{info.id}.");
+                    EditorUtility.DisplayDialog("Rebuild snapshot", "Unable to rebuild version: snapshot path unavailable.", "OK");
+                    return;
+                }
                 Log.Info($"Snapshot rebuilt for version #{info.id}: {path}");
                 EditorUtility.RevealInFinder(path);
             }

--- a/Editor/Windows/RestorePreviewWindow.cs
+++ b/Editor/Windows/RestorePreviewWindow.cs
@@ -162,7 +162,7 @@ namespace AvatarSmartBackup
             _deltaMetadata = null;
             _resolvedSnapshotRoot = null;
 
-            string srcRoot;
+            string? srcRoot;
             if (_versionId > 0)
             {
                 using var vmInfo = new FileBasedVersionManager();
@@ -175,6 +175,12 @@ namespace AvatarSmartBackup
                 try
                 {
                     srcRoot = VersionRestoreService.PrepareSnapshot(_versionId, forceRebuild: false);
+                    if (string.IsNullOrEmpty(srcRoot))
+                    {
+                        var message = string.Format(L.T("rp.restore.prepare.fail", "Failed to prepare snapshot for version {0}:\n{1}"), _versionId, L.T("rp.restore.snapshot.missing", "Snapshot path unavailable."));
+                        EditorUtility.DisplayDialog(L.T("rp.restore.title", "Restore"), message, "OK");
+                        return;
+                    }
                     var prep = VersionRestoreService.LastResult;
                     _resolvedVersionId = prep?.ResolvedVersionId ?? _versionId;
                     _versionInfo = _resolvedVersionId == _versionId ? requestedInfo : vmInfo.GetVersion(_resolvedVersionId);
@@ -198,20 +204,22 @@ namespace AvatarSmartBackup
                 _snapshotWarning = null;
                 _resolvedVersionId = _versionId;
             }
-            _currentVersionRoot = srcRoot;
-            _resolvedSnapshotRoot = srcRoot;
+            if (string.IsNullOrEmpty(srcRoot)) return;
             if (!Directory.Exists(srcRoot)) return;
+            string resolvedRoot = srcRoot;
+            _currentVersionRoot = resolvedRoot;
+            _resolvedSnapshotRoot = resolvedRoot;
             if (_versionId <= 0)
             {
-                var ok = Path.Combine(srcRoot, "backup.ok");
+                var ok = Path.Combine(resolvedRoot, "backup.ok");
                 if (!File.Exists(ok)) { EditorUtility.DisplayDialog(L.T("rp.restore.title", "Restore"), L.T("rp.restore.incomplete", "Backup in progress or not complete."), "OK"); return; }
             }
             int added = 0;
             void Enumerate(bool relaxed)
             {
-                foreach (var src in Directory.GetFiles(srcRoot, "*", SearchOption.AllDirectories))
+                foreach (var src in Directory.GetFiles(resolvedRoot, "*", SearchOption.AllDirectories))
                 {
-                    string rel = BackupManager.MakeRelTo(src, srcRoot).Replace("\\", "/");
+                    string rel = BackupManager.MakeRelTo(src, resolvedRoot).Replace("\\", "/");
                     if (rel.StartsWith("delta/", StringComparison.OrdinalIgnoreCase)) continue;
                     if (!relaxed && !rel.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase)) continue;
                     if (rel.Equals("manifest.json", StringComparison.OrdinalIgnoreCase) || rel.Equals("backup.ok", StringComparison.OrdinalIgnoreCase) || rel.Equals("version.ok", StringComparison.OrdinalIgnoreCase)) continue;
@@ -916,7 +924,7 @@ namespace AvatarSmartBackup
 
         void DoRestore(bool restoreAsCopy = false)
         {
-            string srcRoot;
+            string? srcRoot;
             if (_versionId > 0)
             {
                 try
@@ -925,6 +933,12 @@ namespace AvatarSmartBackup
                     if (string.IsNullOrEmpty(srcRoot) || !Directory.Exists(srcRoot))
                     {
                         srcRoot = VersionRestoreService.PrepareSnapshot(_versionId, forceRebuild: false);
+                        if (string.IsNullOrEmpty(srcRoot))
+                        {
+                            var message = string.Format(L.T("rp.restore.prepare.fail", "Failed to prepare snapshot for version {0}:\n{1}"), _versionId, L.T("rp.restore.snapshot.missing", "Snapshot path unavailable."));
+                            EditorUtility.DisplayDialog(L.T("rp.restore.title", "Restore"), message, "OK");
+                            return;
+                        }
                     }
                     var prep = VersionRestoreService.LastResult;
                     _resolvedVersionId = prep?.ResolvedVersionId ?? _versionId;
@@ -961,11 +975,18 @@ namespace AvatarSmartBackup
                 _snapshotWarning = null;
             }
 
+            if (string.IsNullOrEmpty(srcRoot))
+            {
+                EditorUtility.DisplayDialog(L.T("rp.restore.title", "Restore"), L.T("rp.version.notfound", "Version files not found."), "OK");
+                return;
+            }
             if (!Directory.Exists(srcRoot))
             {
                 EditorUtility.DisplayDialog(L.T("rp.restore.title", "Restore"), L.T("rp.version.notfound", "Version files not found."), "OK");
                 return;
             }
+
+            string activeSrcRoot = srcRoot;
 
             string targetRoot;
             if (restoreAsCopy)
@@ -979,7 +1000,7 @@ namespace AvatarSmartBackup
                 targetRoot = FileUtilEx.ProjectRoot;
             }
 
-            _currentVersionRoot = srcRoot;
+            _currentVersionRoot = activeSrcRoot;
 
             if (!restoreAsCopy && _backupBefore)
             {
@@ -1009,7 +1030,7 @@ namespace AvatarSmartBackup
             {
                 if (!_selected[i]) continue;
                 string rel = _files[i].Replace("/", Path.DirectorySeparatorChar.ToString());
-                string src = Path.Combine(srcRoot, rel);
+                string src = Path.Combine(activeSrcRoot, rel);
                 string dst = Path.Combine(targetRoot, rel);
                 try
                 {
@@ -1166,7 +1187,13 @@ Destination: {1}"), restored, targetRoot), "OK");
             {
                 try
                 {
-                    _resolvedSnapshotRoot = VersionRestoreService.PrepareSnapshot(_versionId, forceRebuild: true);
+                    var snapshotRoot = VersionRestoreService.PrepareSnapshot(_versionId, forceRebuild: true);
+                    if (string.IsNullOrEmpty(snapshotRoot))
+                    {
+                        Log.Warn("Restore rescan failed: snapshot path unavailable.");
+                        return;
+                    }
+                    _resolvedSnapshotRoot = snapshotRoot;
                     var prep = VersionRestoreService.LastResult;
                     _resolvedVersionId = prep?.ResolvedVersionId ?? _versionId;
                     _snapshotWarning = prep?.Message ?? VersionRestoreService.LastWarning;


### PR DESCRIPTION
## Summary
- treat manifest loading and selection normalization as nullable in the backup manager
- update version restore/version manager logic to use nullable references and guard missing snapshot data
- ensure restore UI gracefully handles missing snapshot paths when rebuilds fail

## Testing
- not run (Unity-specific build/test tooling not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd4e9ac5448322baf0b8dae0ce10dd