### PR TITLE
Fix nullable warnings in editor windows and services

### DIFF
--- a/Editor/Backup/BackupEvents.cs
+++ b/Editor/Backup/BackupEvents.cs
@@ -30,7 +30,7 @@ namespace AvatarSmartBackup
 
     internal static class BackupEvents
     {
-        public static event Action<BackupRunSummary> BackupCompleted;
+        public static event Action<BackupRunSummary>? BackupCompleted;
 
         public static void RaiseCompleted(in BackupRunSummary summary)
         {

--- a/Editor/Backup/TimerService.cs
+++ b/Editor/Backup/TimerService.cs
@@ -11,13 +11,13 @@ namespace AvatarSmartBackup
     {
         static readonly double UpdateEverySec = 2.0; // Reduced frequency for less overhead (was 0.5s)
         static double _nextTick;
-        static BackupSettings _cached = null!;
+        static BackupSettings? _cached;
         static double _nextReload;
 
         static TimerService()
         {
             EditorApplication.update += Update;
-            var settings = BackupManager.LoadSettings();
+            var settings = BackupManager.LoadSettings() ?? new BackupSettings();
             _ = BackupManager.EnsureBenchmarkAsync(settings);
             if (settings.autoRunOnLoad) StartTimerIfNeeded(settings);
             TryHookVRChat();
@@ -27,10 +27,16 @@ namespace AvatarSmartBackup
         {
             if (_cached == null || EditorApplication.timeSinceStartup >= _nextReload)
             {
-                _cached = BackupManager.LoadSettings();
+                _cached = BackupManager.LoadSettings() ?? new BackupSettings();
                 _nextReload = EditorApplication.timeSinceStartup + 10.0; // reload every 10s
             }
-            return _cached;
+            var cached = _cached;
+            if (cached == null)
+            {
+                cached = new BackupSettings();
+                _cached = cached;
+            }
+            return cached;
         }
         public static void InvalidateSettingsCache() { _cached = null; _nextReload = 0; }
 

--- a/Editor/Utils/IncrementalCollector.cs
+++ b/Editor/Utils/IncrementalCollector.cs
@@ -10,7 +10,7 @@ namespace AvatarSmartBackup
     internal static class IncrementalCollector
     {
         static readonly HashSet<string> Changed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        static FileSystemWatcher _watcher;
+        static FileSystemWatcher? _watcher;
 
         static IncrementalCollector()
         {

--- a/Editor/Windows/AvatarSmartBackupWindow.cs
+++ b/Editor/Windows/AvatarSmartBackupWindow.cs
@@ -19,19 +19,19 @@ namespace AvatarSmartBackup
     {
         Vector2 _scroll;
         Vector2 _versionsScroll;
-        BackupSettings _settings;
+        BackupSettings _settings = new BackupSettings();
         // Include/Exclude UI temp fields
         string _newIncludePattern = string.Empty;
         string _newExcludePattern = string.Empty;
         string _includePrefix = string.Empty;
         string _excludePrefix = string.Empty;
-        UnityEngine.Object _includeFolderObj;
-        UnityEngine.Object _excludeFolderObj;
+        UnityEngine.Object? _includeFolderObj;
+        UnityEngine.Object? _excludeFolderObj;
         // Signature caching for gating manual version creation
         struct BackupSignature { public long size; public int count; }
         BackupSignature? _cachedCurrentSig; double _cachedCurrentSigTime;
-        GUIStyle _selectedTitleStyle; // enlarged style for selected version title
-        List<VersionInfo> _cachedVersions; // cached index
+        GUIStyle? _selectedTitleStyle; // enlarged style for selected version title
+        List<VersionInfo>? _cachedVersions; // cached index
         int _renamingId = -1; string _renameBuffer = string.Empty; // rename state
         int _selectedVersionId = -1; // selected version id (default latest)
         // Doppio click tracking per apertura rapida preview
@@ -44,8 +44,8 @@ namespace AvatarSmartBackup
         static readonly Color BadgeColorRemoved = new Color(0.75f, 0.25f, 0.25f, 0.22f);
         const float BadgeWidth = 128f;
         const int ManualCheckpointMax = 12;
-        static GUIStyle _badgeStyle;
-        static Texture2D _texExplorer; static bool _texTried;
+        static GUIStyle? _badgeStyle;
+        static Texture2D? _texExplorer; static bool _texTried;
         static bool _forceBackupTabOnOpen;
         void EnsureTextures()
         {
@@ -94,8 +94,12 @@ namespace AvatarSmartBackup
         }
         void OnEnable()
         {
-            _settings = BackupManager.LoadSettings();
-            if (_forceBackupTabOnOpen && _settings != null)
+            var loaded = BackupManager.LoadSettings();
+            if (loaded != null)
+            {
+                _settings = loaded;
+            }
+            if (_forceBackupTabOnOpen)
             {
                 _settings._activeTab = 0;
                 _settings._uiTabInitialized = true;
@@ -181,8 +185,9 @@ namespace AvatarSmartBackup
         }
         void RunOnboardingIfNeeded()
         {
-            if (_settings == null)
-                _settings = BackupManager.LoadSettings();
+            var loaded = BackupManager.LoadSettings();
+            if (loaded != null)
+                _settings = loaded;
 
             if (_settings.onboardingCompleted)
                 return;
@@ -510,8 +515,7 @@ namespace AvatarSmartBackup
                 // Hard reset di sicurezza per evitare stato disabled ereditato
                 GUI.enabled = true;
                 bool isSelected = v.id == _selectedVersionId;
-                if (_selectedTitleStyle == null)
-                    _selectedTitleStyle = new GUIStyle(EditorStyles.boldLabel) { fontSize = EditorStyles.boldLabel.fontSize + 1 };
+                var selectedTitleStyle = _selectedTitleStyle ??= new GUIStyle(EditorStyles.boldLabel) { fontSize = EditorStyles.boldLabel.fontSize + 1 };
                 EnsureTextures();
                 // Begin card content
                 EditorGUILayout.BeginVertical(GUI.skin.box);
@@ -519,7 +523,7 @@ namespace AvatarSmartBackup
                 if (GUILayout.Button(new GUIContent(v.pinned ? "★" : "☆", v.pinned ? "Unpin" : "Pin"), GUILayout.Width(24))) pendingTogglePin = v.id;
                 Rect starRect = GUILayoutUtility.GetLastRect(); // rect of the star button
                 string title = BuildVersionCardTitle(v, latest != null && latest.id == v.id);
-                EditorGUILayout.LabelField(title, isSelected ? _selectedTitleStyle : EditorStyles.boldLabel);
+                EditorGUILayout.LabelField(title, isSelected ? selectedTitleStyle : EditorStyles.boldLabel);
                 GUILayout.FlexibleSpace();
                 Rect folderBtnRect = GUILayoutUtility.GetRect(20, 18, GUILayout.Width(20));
                 if (_texExplorer != null && Event.current.type == EventType.Repaint)
@@ -767,11 +771,8 @@ namespace AvatarSmartBackup
         {
             get
             {
-                if (_badgeStyle == null)
-                {
-                    _badgeStyle = new GUIStyle(EditorStyles.miniBoldLabel) { alignment = TextAnchor.MiddleCenter };
-                }
-                return _badgeStyle;
+                var style = _badgeStyle ??= new GUIStyle(EditorStyles.miniBoldLabel) { alignment = TextAnchor.MiddleCenter };
+                return style;
             }
         }
 
@@ -1201,7 +1202,7 @@ namespace AvatarSmartBackup
             }
         }
 
-        static bool DrawIncludeExcludeSection(string title, List<string> list, ref string newExt, ref string newPrefix, ref UnityEngine.Object folderObj)
+        static bool DrawIncludeExcludeSection(string title, List<string> list, ref string newExt, ref string newPrefix, ref UnityEngine.Object? folderObj)
         {
             bool changed = false;
             EditorGUILayout.BeginHorizontal();
@@ -1225,20 +1226,23 @@ namespace AvatarSmartBackup
             {
                 if (GUILayout.Button("Add", GUILayout.Width(60)))
                 {
-                    string p = AssetDatabase.GetAssetPath(folderObj);
-                    if (string.IsNullOrEmpty(p) || !AssetDatabase.IsValidFolder(p))
+                    if (folderObj != null)
                     {
-                        EditorUtility.DisplayDialog("Not a folder", "Please select a folder inside the Project window.", "OK");
-                    }
-                    else
-                    {
-                        if (!p.EndsWith("/")) p += "/";
-                        if (!list.Contains(p))
+                        string p = AssetDatabase.GetAssetPath(folderObj);
+                        if (string.IsNullOrEmpty(p) || !AssetDatabase.IsValidFolder(p))
                         {
-                            list.Add(p);
-                            changed = true;
+                            EditorUtility.DisplayDialog("Not a folder", "Please select a folder inside the Project window.", "OK");
                         }
-                        folderObj = null;
+                        else
+                        {
+                            if (!p.EndsWith("/")) p += "/";
+                            if (!list.Contains(p))
+                            {
+                                list.Add(p);
+                                changed = true;
+                            }
+                            folderObj = null;
+                        }
                     }
                 }
             }

--- a/Editor/Windows/RestorePreviewWindow.cs
+++ b/Editor/Windows/RestorePreviewWindow.cs
@@ -25,7 +25,7 @@ namespace AvatarSmartBackup
     bool _backupBefore = true;
     bool _hideMeta = true;
     // Easy/Advanced mode bridge
-    BackupSettings _settings;
+    BackupSettings? _settings;
     bool _easyMode = false;
     bool _requireModeChoice = false;
     bool _easyBannerDismissed = false;
@@ -47,19 +47,19 @@ namespace AvatarSmartBackup
     List<CategoryGroup> _categoriesOrdered = new List<CategoryGroup>();
     Dictionary<string,int> _fileIndex = new Dictionary<string,int>(StringComparer.OrdinalIgnoreCase); // rel -> index in _files
     // Manifest MD5 map (rel -> md5) se disponibile per la versione
-    Dictionary<string,string> _md5Map = null;
+    Dictionary<string,string>? _md5Map;
     // Async scan state
     bool _isScanning = false;
     int _scanTotal = 0, _scanProcessed = 0;
     double _scanStartTime;
-    CancellationTokenSource _scanCts;
+    CancellationTokenSource? _scanCts;
     ConcurrentQueue<(int idx, DiffState state, long sizeVer, long sizeProj)> _scanResults = new ConcurrentQueue<(int, DiffState, long, long)>();
     bool _drainHookAdded = false;
-    string _currentVersionRoot;
-    VersionInfo _versionInfo;
-    VersionDeltaMetadata _deltaMetadata;
-    string _resolvedSnapshotRoot;
-    string _snapshotWarning;
+    string? _currentVersionRoot;
+    VersionInfo? _versionInfo;
+    VersionDeltaMetadata? _deltaMetadata;
+    string? _resolvedSnapshotRoot;
+    string? _snapshotWarning;
     // (HashCache disabled fallback) – se HashCache.cs non ancora compilato nell'ambiente, usiamo MD5 diretto.
 
     const string PREF_FOLD_SUMMARY = "ASB_Restore_Fold_Summary";
@@ -73,8 +73,8 @@ namespace AvatarSmartBackup
     static readonly Color SummaryColorChanged = new Color(0.77f, 0.55f, 0.16f, 0.22f);
     static readonly Color SummaryColorRemoved = new Color(0.75f, 0.25f, 0.25f, 0.22f);
     const float SummaryBadgeWidth = 150f;
-    static GUIStyle _summaryBadgeLabelStyle;
-    static GUIStyle _summaryTypeLabelStyle;
+    static GUIStyle? _summaryBadgeLabelStyle;
+    static GUIStyle? _summaryTypeLabelStyle;
 
         void OnEnable()
         {
@@ -100,34 +100,37 @@ namespace AvatarSmartBackup
             if (!force && _settings != null && EditorApplication.timeSinceStartup < _nextSettingsRefresh)
                 return;
 
+            BackupSettings? loaded = null;
             try
             {
-                _settings = BackupManager.LoadSettings();
+                loaded = BackupManager.LoadSettings();
             }
             catch (Exception ex)
             {
                 Log.Warn("RestorePreview: failed to load settings " + ex.Message);
-                _settings = new BackupSettings { onboardingCompleted = true, easyMode = false };
+                loaded = new BackupSettings { onboardingCompleted = true, easyMode = false };
             }
 
+            _settings = loaded;
             _nextSettingsRefresh = EditorApplication.timeSinceStartup + 5f;
 
-            if (_settings == null)
+            var settings = _settings;
+            if (settings == null)
             {
                 _easyMode = false;
                 _requireModeChoice = false;
                 return;
             }
 
-            bool easyFromSettings = _settings.easyMode || !_settings.AdvancedMode;
-            if (_settings.easyMode != easyFromSettings && _settings.onboardingCompleted)
+            bool easyFromSettings = settings.easyMode || !settings.AdvancedMode;
+            if (settings.easyMode != easyFromSettings && settings.onboardingCompleted)
             {
-                _settings.easyMode = easyFromSettings;
-                try { BackupManager.SaveSettings(_settings); }
+                settings.easyMode = easyFromSettings;
+                try { BackupManager.SaveSettings(settings); }
                 catch (Exception ex) { Log.Warn("RestorePreview: failed to sync easy mode flag " + ex.Message); }
             }
 
-            _requireModeChoice = !_settings.onboardingCompleted;
+            _requireModeChoice = !settings.onboardingCompleted;
             _easyMode = easyFromSettings;
             if (_requireModeChoice)
             {
@@ -1100,12 +1103,12 @@ Destination: {1}"), restored, targetRoot), "OK");
         {
             var rect = GUILayoutUtility.GetRect(SummaryBadgeWidth, 20f, GUILayout.MaxWidth(SummaryBadgeWidth));
             EditorGUI.DrawRect(rect, tint);
-            _summaryBadgeLabelStyle ??= new GUIStyle(EditorStyles.miniBoldLabel)
+            var labelStyle = _summaryBadgeLabelStyle ??= new GUIStyle(EditorStyles.miniBoldLabel)
             {
                 alignment = TextAnchor.MiddleCenter,
                 normal = { textColor = Color.white }
             };
-            GUI.Label(rect, text, _summaryBadgeLabelStyle);
+            GUI.Label(rect, text, labelStyle);
         }
 
         void DrawVersionTypeBadge()
@@ -1116,7 +1119,7 @@ Destination: {1}"), restored, targetRoot), "OK");
             var rect = EditorGUILayout.GetControlRect(false, 22f);
             var tint = _versionInfo.isCheckpoint ? SummaryColorCheckpoint : SummaryColorIncremental;
             EditorGUI.DrawRect(rect, tint);
-            _summaryTypeLabelStyle ??= new GUIStyle(EditorStyles.miniBoldLabel)
+            var typeLabelStyle = _summaryTypeLabelStyle ??= new GUIStyle(EditorStyles.miniBoldLabel)
             {
                 alignment = TextAnchor.MiddleLeft,
                 normal = { textColor = Color.white }
@@ -1124,7 +1127,7 @@ Destination: {1}"), restored, targetRoot), "OK");
             string label = _versionInfo.isCheckpoint
                 ? AvatarSmartBackup.Localization.L.T("vc.summary.checkpoint", "Full checkpoint (complete snapshot).")
                 : string.Format(AvatarSmartBackup.Localization.L.T("vc.summary.incremental", "Incremental version (based on checkpoint #{0})."), _versionInfo.checkpointId > 0 ? _versionInfo.checkpointId.ToString() : "--");
-            GUI.Label(new Rect(rect.x + 8f, rect.y + 3f, rect.width - 16f, rect.height - 6f), label, _summaryTypeLabelStyle);
+            GUI.Label(new Rect(rect.x + 8f, rect.y + 3f, rect.width - 16f, rect.height - 6f), label, typeLabelStyle);
         }
 
         void RefreshCategoryView(CategoryGroup cat, CategoryViewCache cache)

--- a/Editor/Windows/VersionHistoryWindow.cs
+++ b/Editor/Windows/VersionHistoryWindow.cs
@@ -13,7 +13,7 @@ namespace AvatarSmartBackup
         private Vector2 _scrollPosition;
         private List<VersionInfo> _versions = new List<VersionInfo>();
         private bool _isLoading = true;
-        private string _errorMessage = null;
+        private string? _errorMessage;
         // [MenuItem("Tools/Avatar Smart Backup/Versions")]
         public static void Open()
         {


### PR DESCRIPTION
## Summary
- mark delayed editor window fields as nullable or provide safe defaults to eliminate CS8618/CS860x warnings
- guard timer service and backup events against missing settings or listeners while keeping default behaviours intact
- allow optional Unity objects and error messages to be null and refresh include/exclude UI handling accordingly

## Testing
- `dotnet build tests/AvatarSmartBackups.Tests/AvatarSmartBackups.Tests.csproj` *(fails: dotnet CLI not available in container)*
- Unity Editor smoke test *(not run: Unity editor not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5d2a06d4832285e1c7f9a5c5f1ab