### PR TITLE
Add guided restore wizard for easy mode

### DIFF
--- a/Editor/Config/BackupLayoutSchema.cs
+++ b/Editor/Config/BackupLayoutSchema.cs
@@ -1,0 +1,109 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+
+namespace AvatarSmartBackup.Config
+{
+    /// <summary>
+    /// Declarative layout description for editor windows that expose Easy/Advanced modes.
+    /// Blocks are listed once and tagged with the modes they should appear in, allowing the
+    /// rendering code to iterate the schema instead of sprinkling conditionals across the UI.
+    /// <para>
+    /// To add a new block:
+    /// <list type="number">
+    /// <item>Add an entry to the corresponding <see cref="MainWindowBlock"/> or <see cref="RestorePreviewBlock"/> enum.</item>
+    /// <item>Insert a <see cref="LayoutBlock{TBlock}"/> entry with the desired <see cref="LayoutMode"/> flags.</item>
+    /// <item>Handle the new enum value inside the switch statement that renders the window.</item>
+    /// </list>
+    /// Keep the Easy and Advanced sequences aligned to avoid regressions. Example order:
+    /// <code>
+    /// // Easy tab
+    /// Header → AutomaticInfo → ModeSelector → ModeSync → EasyDashboard → BodySpacing
+    /// // Advanced tab
+    /// Header → AutomaticInfo → ModeSelector → ModeSync → Scheduler → PrimaryActions → VersionsOverview → BodySpacing → AdvancedOverview → AdvancedSettings
+    /// </code>
+    /// The restore preview window follows a similar pattern where each block is tagged for the
+    /// correct mode, so new blocks should follow the same procedure.
+    /// </summary>
+    internal static class BackupLayoutSchema
+    {
+        [Flags]
+        internal enum LayoutMode
+        {
+            Easy = 1 << 0,
+            Advanced = 1 << 1,
+            Any = Easy | Advanced
+        }
+
+        internal readonly struct LayoutBlock<TBlock>
+        {
+            public LayoutBlock(TBlock id, LayoutMode modes)
+            {
+                Id = id;
+                Modes = modes;
+            }
+
+            public TBlock Id { get; }
+            public LayoutMode Modes { get; }
+
+            public bool Supports(LayoutMode mode) => (Modes & mode) != 0;
+        }
+
+        internal enum MainWindowBlock
+        {
+            Header,
+            AutomaticInfo,
+            ModeSelector,
+            ModeSync,
+            EasyDashboard,
+            Scheduler,
+            PrimaryActions,
+            VersionsOverview,
+            BodySpacing,
+            AdvancedOverview,
+            AdvancedSettings,
+        }
+
+        internal enum RestorePreviewBlock
+        {
+            EasyBanner,
+            HelperBanner,
+            Summary,
+            Filters,
+            Selection,
+            Files,
+            Footer,
+        }
+
+        static readonly LayoutBlock<MainWindowBlock>[] s_mainWindowBlocks =
+        {
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.Header, LayoutMode.Any),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.AutomaticInfo, LayoutMode.Any),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.ModeSelector, LayoutMode.Any),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.ModeSync, LayoutMode.Any),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.EasyDashboard, LayoutMode.Easy),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.Scheduler, LayoutMode.Advanced),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.PrimaryActions, LayoutMode.Advanced),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.VersionsOverview, LayoutMode.Advanced),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.BodySpacing, LayoutMode.Any),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.AdvancedOverview, LayoutMode.Advanced),
+            new LayoutBlock<MainWindowBlock>(MainWindowBlock.AdvancedSettings, LayoutMode.Advanced),
+        };
+
+        static readonly LayoutBlock<RestorePreviewBlock>[] s_restorePreviewBlocks =
+        {
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.EasyBanner, LayoutMode.Easy),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.HelperBanner, LayoutMode.Any),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.Summary, LayoutMode.Any),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.Filters, LayoutMode.Any),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.Selection, LayoutMode.Any),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.Files, LayoutMode.Any),
+            new LayoutBlock<RestorePreviewBlock>(RestorePreviewBlock.Footer, LayoutMode.Any),
+        };
+
+        internal static IReadOnlyList<LayoutBlock<MainWindowBlock>> MainWindowBlocks => s_mainWindowBlocks;
+
+        internal static IReadOnlyList<LayoutBlock<RestorePreviewBlock>> RestorePreviewBlocks => s_restorePreviewBlocks;
+    }
+}
+#endif

--- a/Editor/Windows/AvatarSmartBackupWindow.cs
+++ b/Editor/Windows/AvatarSmartBackupWindow.cs
@@ -3,6 +3,7 @@ using System;
 using UnityEditor;
 using UnityEngine;
 using AvatarSmartBackup.Backup;
+using AvatarSmartBackup.Config;
 
 namespace AvatarSmartBackup
 {
@@ -10,8 +11,6 @@ namespace AvatarSmartBackup
     {
         BackupWindowContext? _context;
         BackupSharedView? _sharedView;
-        BackupEasyView? _easyView;
-        BackupAdvancedView? _advancedView;
         BackupVersionsView? _versionsView;
 
         static bool _forceBackupTabOnOpen;
@@ -66,8 +65,6 @@ namespace AvatarSmartBackup
             _context?.Dispose();
             _context = null;
             _sharedView = null;
-            _easyView = null;
-            _advancedView = null;
             _versionsView = null;
         }
 
@@ -87,9 +84,57 @@ namespace AvatarSmartBackup
         {
             var context = Context;
             _sharedView ??= new BackupSharedView(context);
-            _easyView ??= new BackupEasyView(context, _sharedView);
-            _advancedView ??= new BackupAdvancedView(context, _sharedView);
             _versionsView ??= new BackupVersionsView(context);
+        }
+
+        void DrawBackupTab()
+        {
+            if (_sharedView == null)
+                return;
+
+            var currentMode = Context.Settings.easyMode ? BackupLayoutSchema.LayoutMode.Easy : BackupLayoutSchema.LayoutMode.Advanced;
+            foreach (var block in BackupLayoutSchema.MainWindowBlocks)
+            {
+                if (!block.Supports(currentMode))
+                    continue;
+
+                switch (block.Id)
+                {
+                    case BackupLayoutSchema.MainWindowBlock.Header:
+                        _sharedView.DrawHeader();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.AutomaticInfo:
+                        _sharedView.DrawAutomaticBackupInfo(currentMode);
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.ModeSelector:
+                        _sharedView.DrawModeSelector();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.ModeSync:
+                        _sharedView.SyncModeFlags(currentMode);
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.EasyDashboard:
+                        _sharedView.DrawEasyDashboard();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.Scheduler:
+                        _sharedView.DrawSchedulerSection();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.PrimaryActions:
+                        _sharedView.DrawPrimaryActions();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.VersionsOverview:
+                        _sharedView.DrawVersionsOverview();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.BodySpacing:
+                        _sharedView.DrawBodySpacing();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.AdvancedOverview:
+                        _sharedView.DrawAdvancedOverview();
+                        break;
+                    case BackupLayoutSchema.MainWindowBlock.AdvancedSettings:
+                        _sharedView.DrawAdvancedSettings();
+                        break;
+                }
+            }
         }
 
         void OnGUI()
@@ -112,10 +157,7 @@ namespace AvatarSmartBackup
                 context.Scroll = EditorGUILayout.BeginScrollView(context.Scroll);
                 if (context.Settings._activeTab == 0)
                 {
-                    if (context.Settings.easyMode)
-                        _easyView!.Draw();
-                    else
-                        _advancedView!.Draw();
+                    DrawBackupTab();
                 }
                 else
                 {

--- a/Editor/Windows/Backup/BackupSharedView.cs
+++ b/Editor/Windows/Backup/BackupSharedView.cs
@@ -5,6 +5,9 @@ using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+using AvatarSmartBackup.Config;
+using AvatarSmartBackup.Easy;
+using AvatarSmartBackup.Shared;
 
 namespace AvatarSmartBackup.Backup
 {
@@ -12,10 +15,33 @@ namespace AvatarSmartBackup.Backup
     {
         const int ManualCheckpointMax = 12;
         readonly BackupWindowContext _context;
+        readonly StatusBanner _statusBanner;
+        readonly SchedulerSection _schedulerSection;
+        readonly VersionsCard _versionsCard;
+        readonly EasyDashboardView _easyDashboard;
 
         public BackupSharedView(BackupWindowContext context)
         {
             _context = context;
+            _statusBanner = new StatusBanner(context.InfoBanner);
+            _schedulerSection = new SchedulerSection(context, _statusBanner);
+            _versionsCard = new VersionsCard(context);
+            _easyDashboard = new EasyDashboardView(context, _statusBanner);
+        }
+
+        public void DrawHeader()
+        {
+            _context.RecordLayoutMarker("Header");
+            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("window.main.header", "Avatar Smart Backup"), EditorStyles.boldLabel);
+        }
+
+        public void DrawAutomaticBackupInfo(BackupLayoutSchema.LayoutMode mode)
+        {
+            _context.RecordLayoutMarker("AutomaticInfo");
+            string infoText = mode == BackupLayoutSchema.LayoutMode.Advanced
+                ? AvatarSmartBackup.Localization.L.T("window.main.autobackup.help.advanced", "Automatic backups run silently. Use manual backups when you need an immediate checkpoint.")
+                : AvatarSmartBackup.Localization.L.T("window.main.autobackup.help.easy", "Backups run in the background. The quick actions below let you react instantly.");
+            EditorGUILayout.LabelField(infoText, EditorStyles.wordWrappedMiniLabel);
         }
 
         public void DrawModeSelector()
@@ -34,139 +60,20 @@ namespace AvatarSmartBackup.Backup
             }
         }
 
-        public void DrawSchedulerSection()
+        public void SyncModeFlags(BackupLayoutSchema.LayoutMode mode)
         {
-            _context.RecordLayoutMarker("SchedulerSection");
-            EditorGUILayout.BeginVertical("box");
-            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.autobackups.title", "Automatic Backups"), EditorStyles.boldLabel);
-            GUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            bool running = Session.IsRunning;
-            Color prev = GUI.backgroundColor;
-            GUI.backgroundColor = running ? new Color(0.25f, 0.55f, 0.25f, 1f) : new Color(0.45f, 0.2f, 0.2f, 1f);
-            if (GUILayout.Button(new GUIContent(running ? AvatarSmartBackup.Localization.L.T("ui.autobackups.on", "Automatic Backups: ON") : AvatarSmartBackup.Localization.L.T("ui.autobackups.off", "Automatic Backups: OFF"), AvatarSmartBackup.Localization.L.T("ui.autobackups.toggle.tt", "Toggle background backup scheduler")), GUILayout.Width(220), GUILayout.Height(30)))
-            {
-                _context.ToggleScheduler();
-            }
-            GUI.backgroundColor = prev;
-            GUILayout.FlexibleSpace();
-            GUILayout.EndHorizontal();
-            EditorGUILayout.Space(2);
-            {
-                var nextLabel = AvatarSmartBackup.Localization.L.T("ui.autobackups.next", "Next");
-                var lastLabel = AvatarSmartBackup.Localization.L.T("ui.autobackups.last", "Last");
-                var never = AvatarSmartBackup.Localization.L.T("ui.never", "never");
-                var nextStr = Session.NextRunUtc?.ToLocalTime().ToString("HH:mm:ss") ?? "--";
-                var lastStr = Session.LastBackupUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? never;
-                EditorGUILayout.LabelField($"{nextLabel}: {nextStr}    {lastLabel}: {lastStr}");
-            }
-            DrawDiskStatusRow();
-            if (_context.Settings.filtersDirty && _context.Settings.easyMode)
-            {
-                using (_context.Info(MessageType.Info, AvatarSmartBackup.Localization.L.T("ui.filters.pending", "Filter changes pending. The next backup will create a full checkpoint to apply the new scope.")))
-                {
-                    GUILayout.Space(2);
-                }
-            }
-            if (_context.Settings.AdvancedMode)
-            {
-                EditorGUILayout.Space(4);
-                DrawIntervalControls();
-                int effCopy = BackupManager.EffectiveCopyMBps(_context.Settings);
-                if (_context.Settings.lastBackupBytes > 0 && effCopy > 0)
-                {
-                    double secNeeded = _context.Settings.lastBackupBytes / (effCopy * 1024.0 * 1024.0);
-                    double intervalSeconds = _context.Settings.intervalInSeconds ? _context.Settings.intervalMinutes : _context.Settings.intervalMinutes * 60.0;
-                    if (secNeeded > intervalSeconds)
-                    {
-                        double minutesNeeded = secNeeded / 60.0;
-                        double mb = _context.Settings.lastBackupBytes / (1024.0 * 1024.0);
-                        using (_context.Info(MessageType.Warning, AvatarSmartBackup.Localization.L.T("warn.backup.speed", "At {0} MB/s, backing up {1:0.0} MB takes ~{2:0.0} min, exceeding the interval.", effCopy, mb, minutesNeeded)))
-                        {
-                            GUILayout.Space(2);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                EditorGUILayout.Space(4);
-                DrawIntervalControls();
-            }
-            EditorGUILayout.EndVertical();
+            _context.RecordLayoutMarker("ModeSync");
+            bool isEasy = mode == BackupLayoutSchema.LayoutMode.Easy;
+            _context.Settings.easyMode = isEasy;
+            _context.Settings.AdvancedMode = !isEasy;
         }
 
-        void DrawDiskStatusRow()
+        public void DrawSchedulerSection() => _schedulerSection.Draw();
+
+        public void DrawEasyDashboard()
         {
-            var report = DiskSpaceMonitor.LastReport;
-            if (report.Status == DiskSpaceStatus.Unknown)
-                return;
-
-            var snapshot = report.Snapshot;
-            if (snapshot.totalBytes <= 0)
-                return;
-
-            string summary = $"Disk free: {DiskSpaceMonitor.FormatBytes(snapshot.freeBytes)} / {DiskSpaceMonitor.FormatBytes(snapshot.totalBytes)}";
-            summary += $" • Backups: {DiskSpaceMonitor.FormatBytes(snapshot.backupSizeBytes)}";
-            if (report.RequiredBytes > 0 && report.Stage != DiskSpaceStage.PostBackup)
-            {
-                summary += $" • Next estimate: {DiskSpaceMonitor.FormatBytes(report.RequiredBytes)}";
-            }
-
-            MessageType type = report.Status switch
-            {
-                DiskSpaceStatus.Warning => MessageType.Warning,
-                DiskSpaceStatus.Critical => MessageType.Error,
-                DiskSpaceStatus.Error => MessageType.Warning,
-                _ => MessageType.Info
-            };
-
-            using (_context.Info(type, summary))
-            {
-                GUILayout.Space(2);
-            }
-        }
-
-        public void DrawIntervalControls()
-        {
-            EditorGUILayout.BeginHorizontal();
-            bool changed = false;
-            string[] unitOptions = { AvatarSmartBackup.Localization.L.T("ui.interval.min", "min"), AvatarSmartBackup.Localization.L.T("ui.interval.sec", "sec") };
-            int currentUnitIndex = _context.Settings.intervalInSeconds ? 1 : 0;
-            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.interval.label", "Interval"), GUILayout.Width(60));
-            int maxValue = _context.Settings.intervalInSeconds ? 3600 : 240;
-            int newInterval = Mathf.Clamp(EditorGUILayout.IntField(_context.Settings.intervalMinutes, GUILayout.Width(70)), 1, maxValue);
-            if (newInterval != _context.Settings.intervalMinutes)
-            {
-                _context.Settings.intervalMinutes = newInterval;
-                changed = true;
-            }
-            int newUnitIndex = EditorGUILayout.Popup(currentUnitIndex, unitOptions, GUILayout.Width(50));
-            if (newUnitIndex != currentUnitIndex)
-            {
-                if (newUnitIndex == 1 && !_context.Settings.intervalInSeconds)
-                {
-                    _context.Settings.intervalMinutes = Mathf.Max(1, _context.Settings.intervalMinutes * 60);
-                    changed = true;
-                }
-                else if (newUnitIndex == 0 && _context.Settings.intervalInSeconds)
-                {
-                    _context.Settings.intervalMinutes = Mathf.Max(1, Mathf.RoundToInt(_context.Settings.intervalMinutes / 60f));
-                    changed = true;
-                }
-                _context.Settings.intervalInSeconds = (newUnitIndex == 1);
-                changed = true;
-            }
-            EditorGUILayout.EndHorizontal();
-            if (changed)
-            {
-                TimerService.InvalidateSettingsCache();
-                if (Session.IsRunning)
-                {
-                    TimerService.ScheduleNextRun(_context.Settings);
-                }
-                _context.RequestRepaint();
-            }
+            _context.RecordLayoutMarker("EasyDashboard");
+            _easyDashboard.Draw();
         }
 
         public void DrawPrimaryActions()
@@ -210,49 +117,12 @@ namespace AvatarSmartBackup.Backup
             EditorGUILayout.EndHorizontal();
         }
 
-        public void DrawVersionsOverview()
-        {
-            _context.RecordLayoutMarker("VersionsOverview");
-            EditorGUILayout.BeginVertical("box");
-            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.latest.title", "Latest Version"), EditorStyles.boldLabel);
-            _context.EnsureVersionsCache();
-            var latest = _context.GetLatestVersionCached();
-            if (latest != null)
-            {
-                EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.latest.label", "Latest Version:"), EditorStyles.miniBoldLabel);
-                string desc = _context.SanitizeInlineLabel(latest.description, AvatarSmartBackup.Localization.L.T("ui.overview.noDescription", "(no description)"));
-                EditorGUILayout.LabelField($"# {latest.id}  {desc}", EditorStyles.miniLabel);
-                var created = _context.ParseCreatedUtc(latest);
-                if (created != DateTime.MinValue)
-                    EditorGUILayout.LabelField($"{AvatarSmartBackup.Localization.L.T("ui.overview.created", "Created:")} {created:yyyy-MM-dd HH:mm:ss}", EditorStyles.miniLabel);
-                {
-                    var filesLbl = AvatarSmartBackup.Localization.L.T("ui.overview.filesSize", "Files");
-                    var sizeLbl = AvatarSmartBackup.Localization.L.T("ui.overview.size", "Size");
-                    EditorGUILayout.LabelField($"{filesLbl}: {latest.fileCount}  {sizeLbl}: {_context.FormatSize(latest.totalSizeBytes)}", EditorStyles.miniLabel);
-                }
-                if (GUILayout.Button(new GUIContent(AvatarSmartBackup.Localization.L.T("ui.overview.gotoVersions", "Go to Versions"), AvatarSmartBackup.Localization.L.T("tt.overview.gotoVersions", "Open Versions tab")), GUILayout.Width(140)))
-                {
-                    _context.Settings._activeTab = 1;
-                }
-            }
-            else
-            {
-                EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.none", "No versions available"), EditorStyles.miniLabel);
-            }
-            EditorGUILayout.EndVertical();
-        }
+        public void DrawVersionsOverview() => _versionsCard.Draw();
 
-        public void DrawEasyModeFooter()
+        public void DrawBodySpacing()
         {
-            _context.RecordLayoutMarker("EasyFooter");
-            EditorGUILayout.BeginVertical("box");
-            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.easy.summary", "Easy mode shows the essentials. Switch to Advanced for detailed controls."), EditorStyles.wordWrappedMiniLabel);
-            if (GUILayout.Button(AvatarSmartBackup.Localization.L.T("ui.easy.switch", "Switch to Advanced"), GUILayout.Width(200)))
-            {
-                _context.Settings.easyMode = false;
-                _context.Settings.AdvancedMode = true;
-            }
-            EditorGUILayout.EndVertical();
+            _context.RecordLayoutMarker("BodySpacing");
+            EditorGUILayout.Space();
         }
 
         public void DrawAdvancedOverview()

--- a/Editor/Windows/Backup/BackupWindowContext.cs
+++ b/Editor/Windows/Backup/BackupWindowContext.cs
@@ -347,7 +347,14 @@ namespace AvatarSmartBackup.Backup
 
             try
             {
-                RestorePreviewWindow.Open(info.id);
+                if (Settings.easyMode && !Settings.AdvancedMode)
+                {
+                    AvatarSmartBackup.Restore.Easy.RestoreEasyWizard.Open(info);
+                }
+                else
+                {
+                    RestorePreviewWindow.Open(info.id);
+                }
             }
             catch (Exception ex)
             {

--- a/Editor/Windows/Easy/EasyDashboardView.cs
+++ b/Editor/Windows/Easy/EasyDashboardView.cs
@@ -1,0 +1,250 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine;
+using AvatarSmartBackup.Backup;
+using AvatarSmartBackup.Localization;
+using AvatarSmartBackup.Shared;
+
+namespace AvatarSmartBackup.Easy
+{
+    internal sealed class EasyDashboardView
+    {
+        readonly BackupWindowContext _context;
+        readonly StatusBanner _statusBanner;
+        EasyDashboardSnapshot _snapshot;
+
+        public EasyDashboardView(BackupWindowContext context, StatusBanner statusBanner)
+        {
+            _context = context;
+            _statusBanner = statusBanner;
+        }
+
+        public EasyDashboardSnapshot LastSnapshot => _snapshot;
+
+        public void Draw()
+        {
+            float viewWidth = EditorGUIUtility.currentViewWidth;
+            bool stackButtons = viewWidth < 420f;
+            _snapshot = new EasyDashboardSnapshot(stackButtons, viewWidth);
+            _context.RecordLayoutMarker(stackButtons ? "EasyDashboard.Compact" : "EasyDashboard.Wide");
+
+            DrawQuickActions(stackButtons);
+            EditorGUILayout.Space(6);
+            DrawSchedulerSummary(stackButtons);
+            EditorGUILayout.Space(6);
+            DrawLatestVersionSummary();
+            DrawDiskStatusWarnings();
+        }
+
+        void DrawQuickActions(bool stackButtons)
+        {
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField(L.T("easy.dashboard.actions.title", "Quick actions"), EditorStyles.boldLabel);
+
+            if (stackButtons)
+            {
+                DrawBackupButton(GUILayout.Height(28));
+                EditorGUILayout.Space(4);
+                DrawRestoreButton(GUILayout.Height(28));
+            }
+            else
+            {
+                EditorGUILayout.BeginHorizontal();
+                DrawBackupButton(GUILayout.Width(160), GUILayout.Height(28));
+                DrawRestoreButton(GUILayout.Width(180), GUILayout.Height(28));
+                GUILayout.FlexibleSpace();
+                EditorGUILayout.EndHorizontal();
+            }
+
+            EditorGUILayout.Space(2);
+            EditorGUILayout.LabelField(
+                L.T("easy.dashboard.actions.microcopy", "Backups run automatically. Trigger a manual run or open the guided restore if you need control right now."),
+                EditorStyles.wordWrappedMiniLabel);
+            EditorGUILayout.EndVertical();
+        }
+
+        void DrawBackupButton(params GUILayoutOption[] options)
+        {
+            bool canManual = true;
+            string tooltip = L.T("tt.backup.now.easy", "Run a backup now (cooldown applies in Easy mode)");
+            if (_context.ShouldThrottleManualBackup)
+            {
+                canManual = false;
+                double rem = _context.RemainingManualCooldown;
+                tooltip = string.Format(L.T("tt.backup.cooldown", "Wait {0:0}s before another manual backup"), rem);
+            }
+
+            using (new EditorGUI.DisabledScope(!canManual || BackupManager.IsBusy))
+            {
+                if (GUILayout.Button(new GUIContent(L.T("ui.backup.now", "Backup Now"), tooltip), options))
+                {
+                    _context.RunBackupNow();
+                }
+            }
+        }
+
+        void DrawRestoreButton(params GUILayoutOption[] options)
+        {
+            _context.EnsureVersionsCache();
+            var latest = _context.GetLatestVersionCached();
+            string tooltip = latest == null
+                ? L.T("tt.latest.none", "No version available")
+                : L.T("tt.easy.restore", "Open the guided restore for the latest version");
+
+            using (new EditorGUI.DisabledScope(latest == null))
+            {
+                if (GUILayout.Button(new GUIContent(L.T("easy.dashboard.restore", "Guided Restore"), tooltip), options) && latest != null)
+                {
+                    _context.OpenPreviewRestore(latest);
+                }
+            }
+        }
+
+        void DrawSchedulerSummary(bool stackButtons)
+        {
+            EditorGUILayout.BeginVertical("box");
+            bool running = Session.IsRunning;
+            EditorGUILayout.LabelField(L.T("easy.dashboard.scheduler.title", "Automatic backups"), EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(
+                running
+                    ? L.T("easy.dashboard.scheduler.running", "Automatic backups are running in the background.")
+                    : L.T("easy.dashboard.scheduler.paused", "Automatic backups are paused."),
+                EditorStyles.wordWrappedMiniLabel);
+
+            EditorGUILayout.Space(2);
+            if (stackButtons)
+            {
+                DrawSchedulerToggle(running, GUILayout.Height(24));
+            }
+            else
+            {
+                EditorGUILayout.BeginHorizontal();
+                DrawSchedulerToggle(running, GUILayout.Width(200), GUILayout.Height(24));
+                GUILayout.FlexibleSpace();
+                DrawScheduleTimes();
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (stackButtons)
+            {
+                EditorGUILayout.Space(2);
+                DrawScheduleTimes();
+            }
+
+            if (_context.Settings.filtersDirty)
+            {
+                EditorGUILayout.Space(2);
+                EditorGUILayout.LabelField(
+                    L.T("easy.dashboard.filters.pending", "Filter changes pending. The next backup will refresh the scope."),
+                    EditorStyles.wordWrappedMiniLabel);
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        void DrawSchedulerToggle(bool running, params GUILayoutOption[] options)
+        {
+            Color prev = GUI.backgroundColor;
+            GUI.backgroundColor = running ? new Color(0.25f, 0.55f, 0.25f, 1f) : new Color(0.45f, 0.2f, 0.2f, 1f);
+            if (GUILayout.Button(new GUIContent(
+                    running ? L.T("ui.autobackups.on", "Automatic Backups: ON") : L.T("ui.autobackups.off", "Automatic Backups: OFF"),
+                    L.T("ui.autobackups.toggle.tt", "Toggle background backup scheduler")),
+                    options))
+            {
+                _context.ToggleScheduler();
+            }
+            GUI.backgroundColor = prev;
+        }
+
+        void DrawScheduleTimes()
+        {
+            var nextLabel = L.T("ui.autobackups.next", "Next");
+            var lastLabel = L.T("ui.autobackups.last", "Last");
+            var never = L.T("ui.never", "never");
+            var nextStr = Session.NextRunUtc?.ToLocalTime().ToString("HH:mm:ss") ?? "--";
+            var lastStr = Session.LastBackupUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? never;
+            EditorGUILayout.LabelField($"{nextLabel}: {nextStr}", EditorStyles.miniLabel);
+            EditorGUILayout.LabelField($"{lastLabel}: {lastStr}", EditorStyles.miniLabel);
+        }
+
+        void DrawLatestVersionSummary()
+        {
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField(L.T("easy.dashboard.latest.title", "Latest version"), EditorStyles.boldLabel);
+            _context.EnsureVersionsCache();
+            var latest = _context.GetLatestVersionCached();
+            if (latest != null)
+            {
+                string desc = _context.SanitizeInlineLabel(latest.description, L.T("ui.overview.noDescription", "(no description)"));
+                EditorGUILayout.LabelField($"#{latest.id}  {desc}", EditorStyles.miniLabel);
+                var created = _context.ParseCreatedUtc(latest);
+                if (created != DateTime.MinValue)
+                    EditorGUILayout.LabelField(created.ToLocalTime().ToString("yyyy-MM-dd HH:mm"), EditorStyles.miniLabel);
+                EditorGUILayout.LabelField(
+                    string.Format(L.T("easy.dashboard.latest.files", "Files: {0}    Size: {1}"), latest.fileCount, _context.FormatSize(latest.totalSizeBytes)),
+                    EditorStyles.miniLabel);
+                if (GUILayout.Button(new GUIContent(L.T("easy.dashboard.latest.openVersions", "Review versions"), L.T("tt.overview.gotoVersions", "Open Versions tab")), GUILayout.Width(140)))
+                {
+                    _context.Settings._activeTab = 1;
+                }
+            }
+            else
+            {
+                EditorGUILayout.LabelField(L.T("easy.dashboard.latest.none", "No versions available yet"), EditorStyles.miniLabel);
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        void DrawDiskStatusWarnings()
+        {
+            var report = DiskSpaceMonitor.LastReport;
+            if (report.Status == DiskSpaceStatus.Unknown)
+                return;
+
+            var snapshot = report.Snapshot;
+            if (snapshot.totalBytes <= 0)
+                return;
+
+            string summary = string.Format(
+                L.T("easy.dashboard.disk.summary", "Disk free: {0} / {1} • Backups: {2}"),
+                DiskSpaceMonitor.FormatBytes(snapshot.freeBytes),
+                DiskSpaceMonitor.FormatBytes(snapshot.totalBytes),
+                DiskSpaceMonitor.FormatBytes(snapshot.backupSizeBytes));
+
+            EditorGUILayout.LabelField(summary, EditorStyles.miniLabel);
+
+            if (report.RequiredBytes > 0 && report.Stage != DiskSpaceStage.PostBackup)
+            {
+                EditorGUILayout.LabelField(
+                    string.Format(L.T("easy.dashboard.disk.next", "Next estimate: {0}"), DiskSpaceMonitor.FormatBytes(report.RequiredBytes)),
+                    EditorStyles.miniLabel);
+            }
+
+            if (report.Status != DiskSpaceStatus.Ok)
+            {
+                MessageType type = report.Status switch
+                {
+                    DiskSpaceStatus.Warning => MessageType.Warning,
+                    DiskSpaceStatus.Critical => MessageType.Error,
+                    DiskSpaceStatus.Error => MessageType.Warning,
+                    _ => MessageType.Info
+                };
+                _statusBanner.Draw(type, report.Message);
+            }
+        }
+    }
+
+    internal readonly struct EasyDashboardSnapshot
+    {
+        public EasyDashboardSnapshot(bool buttonsStacked, float viewWidth)
+        {
+            ButtonsStacked = buttonsStacked;
+            ViewWidth = viewWidth;
+        }
+
+        public bool ButtonsStacked { get; }
+        public float ViewWidth { get; }
+    }
+}
+#endif

--- a/Editor/Windows/Restore/Easy/RestoreEasyWizard.cs
+++ b/Editor/Windows/Restore/Easy/RestoreEasyWizard.cs
@@ -1,0 +1,688 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using AvatarSmartBackup.Localization;
+using AvatarSmartBackup.Shared;
+using VersionInfo = AvatarSmartBackup.VersionInfo;
+using BackupManifest = AvatarSmartBackup.BackupManifest;
+using FileBasedVersionManager = AvatarSmartBackup.FileBasedVersionManager;
+using FileUtilEx = AvatarSmartBackup.FileUtilEx;
+using Log = AvatarSmartBackup.Log;
+using VersionRestoreService = AvatarSmartBackup.VersionRestoreService;
+
+namespace AvatarSmartBackup.Restore.Easy
+{
+    internal sealed class RestoreEasyWizard : EditorWindow
+    {
+        enum WizardStep
+        {
+            SelectVersion,
+            ChooseContent,
+            Confirm
+        }
+
+        enum FilterPreset
+        {
+            Essentials,
+            ScenesAndScripts,
+            Everything
+        }
+
+        sealed class CategoryInfo
+        {
+            public string Name = string.Empty;
+            public readonly List<int> Indices = new List<int>();
+            public bool Selected;
+            public long TotalSize;
+        }
+
+        sealed class EntryInfo
+        {
+            public string RelPath = string.Empty;
+            public long Size;
+            public string Category = string.Empty;
+        }
+
+        readonly ModernInfoBanner _modernBanner = new ModernInfoBanner();
+        StatusBanner? _statusBanner;
+        WizardStep _step = WizardStep.SelectVersion;
+        Vector2 _scroll;
+        Vector2 _versionScroll;
+
+        readonly List<VersionInfo> _versions = new List<VersionInfo>();
+        VersionInfo? _selectedVersion;
+        int _selectedVersionIndex = -1;
+        string? _snapshotRoot;
+        string? _loadError;
+
+        readonly List<EntryInfo> _entries = new List<EntryInfo>();
+        readonly List<CategoryInfo> _categories = new List<CategoryInfo>();
+        readonly List<bool> _selected = new List<bool>();
+        FilterPreset? _activePreset;
+        bool _safetyBackup = true;
+        bool _restoreInProgress;
+        bool _restoreCompleted;
+        string? _completionMessage;
+
+        StatusBanner Banner => _statusBanner ??= new StatusBanner(_modernBanner);
+
+        public static void Open(VersionInfo? initialVersion = null)
+        {
+            var window = CreateInstance<RestoreEasyWizard>();
+            window.titleContent = new GUIContent(L.T("easy.restore.title", "Guided Restore"));
+            window.minSize = new Vector2(560, 420);
+            window.ShowUtility();
+            if (initialVersion != null)
+            {
+                window._selectedVersion = initialVersion;
+                window._selectedVersionIndex = -1;
+                window._step = WizardStep.ChooseContent;
+                window.LoadManifestIfNeeded(force: true);
+            }
+        }
+
+        void OnEnable()
+        {
+            LoadVersions();
+        }
+
+        void LoadVersions()
+        {
+            _versions.Clear();
+            try
+            {
+                using var vm = new FileBasedVersionManager();
+                _versions.AddRange(vm.GetVersions());
+            }
+            catch (Exception ex)
+            {
+                _loadError = ex.Message;
+            }
+
+            if (_selectedVersion != null)
+            {
+                int idx = _versions.FindIndex(v => v.id == _selectedVersion.id);
+                if (idx >= 0) _selectedVersionIndex = idx;
+            }
+        }
+
+        void OnGUI()
+        {
+            EditorGUILayout.LabelField(L.T("easy.restore.header", "Guided Restore"), EditorStyles.boldLabel);
+            EditorGUILayout.Space(4);
+
+            DrawStepIndicator();
+            EditorGUILayout.Space();
+
+            switch (_step)
+            {
+                case WizardStep.SelectVersion:
+                    DrawSelectVersion();
+                    break;
+                case WizardStep.ChooseContent:
+                    DrawChooseContent();
+                    break;
+                case WizardStep.Confirm:
+                    DrawConfirm();
+                    break;
+            }
+        }
+
+        void DrawStepIndicator()
+        {
+            string[] steps =
+            {
+                L.T("easy.restore.step.version", "1. Select backup"),
+                L.T("easy.restore.step.content", "2. Choose content"),
+                L.T("easy.restore.step.confirm", "3. Confirm")
+            };
+
+            EditorGUILayout.BeginHorizontal();
+            for (int i = 0; i < steps.Length; i++)
+            {
+                bool active = (int)_step == i;
+                using (new GuiColorScope(active ? new Color(0.3f, 0.6f, 0.3f, 1f) : GUI.color))
+                {
+                    GUILayout.Label(steps[i], active ? EditorStyles.boldLabel : EditorStyles.miniLabel);
+                }
+                if (i < steps.Length - 1)
+                {
+                    GUILayout.Label("→", EditorStyles.centeredGreyMiniLabel, GUILayout.Width(14));
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        void DrawSelectVersion()
+        {
+            if (!string.IsNullOrEmpty(_loadError))
+            {
+                Banner.Draw(MessageType.Error, string.Format(L.T("easy.restore.load.error", "Unable to load versions: {0}"), _loadError));
+                return;
+            }
+
+            if (_versions.Count == 0)
+            {
+                Banner.Draw(MessageType.Info, L.T("easy.restore.no.versions", "No backups available yet. Run a backup and try again."));
+                return;
+            }
+
+            EditorGUILayout.LabelField(L.T("easy.restore.pick.version", "Choose which backup to restore"), EditorStyles.wordWrappedMiniLabel);
+            EditorGUILayout.Space(4);
+
+            _versionScroll = EditorGUILayout.BeginScrollView(_versionScroll);
+            for (int i = 0; i < _versions.Count; i++)
+            {
+                var v = _versions[i];
+                EditorGUILayout.BeginVertical("box");
+                EditorGUILayout.BeginHorizontal();
+                bool selected = GUILayout.Toggle(_selectedVersionIndex == i, string.Empty, GUILayout.Width(16));
+                if (selected && _selectedVersionIndex != i)
+                {
+                    _selectedVersionIndex = i;
+                    _selectedVersion = v;
+                    _snapshotRoot = null;
+                    _entries.Clear();
+                    _categories.Clear();
+                    _selected.Clear();
+                    _activePreset = null;
+                    _restoreCompleted = false;
+                    _completionMessage = null;
+                }
+                EditorGUILayout.BeginVertical();
+                string desc = string.IsNullOrWhiteSpace(v.description) ? L.T("ui.overview.noDescription", "(no description)") : v.description;
+                EditorGUILayout.LabelField(string.Format("#{0:D3}  {1}", v.id, desc), EditorStyles.label);
+                EditorGUILayout.LabelField(string.Format(L.T("easy.restore.version.meta", "Files: {0}    Size: {1}"), v.fileCount, FormatSize(v.totalSizeBytes)), EditorStyles.miniLabel);
+                DateTime created = ParseCreatedUtc(v);
+                if (created != DateTime.MinValue)
+                    EditorGUILayout.LabelField(created.ToLocalTime().ToString("yyyy-MM-dd HH:mm"), EditorStyles.miniLabel);
+                EditorGUILayout.EndVertical();
+                EditorGUILayout.EndHorizontal();
+                EditorGUILayout.EndVertical();
+            }
+            EditorGUILayout.EndScrollView();
+
+            EditorGUILayout.Space(6);
+            using (new EditorGUI.DisabledScope(_selectedVersion == null))
+            {
+                if (GUILayout.Button(L.T("easy.restore.next", "Next"), GUILayout.Height(26)))
+                {
+                    if (_selectedVersion != null)
+                    {
+                        _step = WizardStep.ChooseContent;
+                        LoadManifestIfNeeded(force: true);
+                    }
+                }
+            }
+        }
+
+        void DrawChooseContent()
+        {
+            if (_selectedVersion == null)
+            {
+                Banner.Draw(MessageType.Warning, L.T("easy.restore.no.version", "Select a backup first."));
+                if (GUILayout.Button(L.T("easy.restore.back", "Back"), GUILayout.Width(120)))
+                    _step = WizardStep.SelectVersion;
+                return;
+            }
+
+            LoadManifestIfNeeded();
+
+            if (!string.IsNullOrEmpty(_loadError))
+            {
+                Banner.Draw(MessageType.Error, string.Format(L.T("easy.restore.manifest.error", "Unable to read backup manifest: {0}"), _loadError));
+                if (GUILayout.Button(L.T("easy.restore.back", "Back"), GUILayout.Width(120)))
+                    _step = WizardStep.SelectVersion;
+                return;
+            }
+
+            if (_entries.Count == 0)
+            {
+                Banner.Draw(MessageType.Info, L.T("easy.restore.empty", "This backup does not contain any files."));
+                if (GUILayout.Button(L.T("easy.restore.back", "Back"), GUILayout.Width(120)))
+                    _step = WizardStep.SelectVersion;
+                return;
+            }
+
+            EditorGUILayout.LabelField(string.Format(L.T("easy.restore.selected.version", "Backup #{0:D3}"), _selectedVersion.id), EditorStyles.boldLabel);
+
+            DrawPresetToolbar();
+            EditorGUILayout.Space(4);
+
+            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            foreach (var cat in _categories)
+            {
+                EditorGUILayout.BeginHorizontal();
+                bool next = EditorGUILayout.ToggleLeft(string.Format("{0} ({1})", cat.Name, cat.Indices.Count), cat.Selected, GUILayout.Width(220));
+                GUILayout.FlexibleSpace();
+                GUILayout.Label(FormatSize(cat.TotalSize), EditorStyles.miniLabel, GUILayout.Width(100));
+                EditorGUILayout.EndHorizontal();
+                if (next != cat.Selected)
+                {
+                    SetCategorySelected(cat, next, fromPreset: false);
+                }
+            }
+            EditorGUILayout.EndScrollView();
+
+            EditorGUILayout.Space(6);
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button(L.T("easy.restore.back", "Back"), GUILayout.Width(120)))
+                _step = WizardStep.SelectVersion;
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(L.T("easy.restore.show.advanced", "Mostra opzioni avanzate"), GUILayout.Width(200)))
+            {
+                RestorePreviewWindow.Open(_selectedVersion.id);
+                Close();
+                GUIUtility.ExitGUI();
+            }
+            GUILayout.FlexibleSpace();
+            using (new EditorGUI.DisabledScope(!HasAnySelection()))
+            {
+                if (GUILayout.Button(L.T("easy.restore.next", "Next"), GUILayout.Width(120)))
+                {
+                    _step = WizardStep.Confirm;
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        void DrawConfirm()
+        {
+            if (_selectedVersion == null)
+            {
+                _step = WizardStep.SelectVersion;
+                DrawSelectVersion();
+                return;
+            }
+
+            if (!HasAnySelection())
+            {
+                Banner.Draw(MessageType.Warning, L.T("easy.restore.empty.selection", "Select at least one category to restore."));
+            }
+
+            if (_restoreCompleted && !string.IsNullOrEmpty(_completionMessage))
+            {
+                Banner.Draw(MessageType.Info, _completionMessage);
+            }
+
+            ComputeSelectionStats(out int selectedFiles, out long selectedSize);
+            EditorGUILayout.LabelField(string.Format(L.T("easy.restore.summary", "Selected files: {0}    Size: {1}"), selectedFiles, FormatSize(selectedSize)), EditorStyles.wordWrappedMiniLabel);
+
+            _safetyBackup = EditorGUILayout.ToggleLeft(new GUIContent(L.T("easy.restore.safety", "Create safety backup before restoring"), L.T("easy.restore.safety.tt", "Copies the current project files to a PreRestore folder.")), _safetyBackup);
+
+            GUILayout.FlexibleSpace();
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button(L.T("easy.restore.back", "Back"), GUILayout.Width(120)))
+            {
+                _step = WizardStep.ChooseContent;
+                return;
+            }
+
+            GUILayout.FlexibleSpace();
+
+            using (new EditorGUI.DisabledScope(_restoreInProgress || !HasAnySelection()))
+            {
+                if (GUILayout.Button(L.T("easy.restore.execute", "Restore"), GUILayout.Width(160), GUILayout.Height(28)))
+                {
+                    PerformRestore();
+                }
+            }
+
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+        }
+
+        void DrawPresetToolbar()
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(L.T("easy.restore.presets", "Presets"), GUILayout.Width(60));
+
+            foreach (FilterPreset preset in Enum.GetValues(typeof(FilterPreset)))
+            {
+                bool active = _activePreset == preset;
+                if (GUILayout.Toggle(active, GetPresetLabel(preset), "Button", GUILayout.Height(22)) != active)
+                {
+                    ApplyPreset(preset);
+                }
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        GUIContent GetPresetLabel(FilterPreset preset)
+        {
+            return preset switch
+            {
+                FilterPreset.ScenesAndScripts => new GUIContent(L.T("easy.restore.preset.scenes", "Scene + script"), L.T("easy.restore.preset.scenes.tt", "Only include scenes and scripts.")),
+                FilterPreset.Everything => new GUIContent(L.T("easy.restore.preset.all", "All files"), L.T("easy.restore.preset.all.tt", "Restore everything from this backup.")),
+                _ => new GUIContent(L.T("easy.restore.preset.essentials", "Essential assets"), L.T("easy.restore.preset.essentials.tt", "Scenes, prefabs, scripts, materials.")),
+            };
+        }
+
+        void ApplyPreset(FilterPreset preset)
+        {
+            HashSet<string> include = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            switch (preset)
+            {
+                case FilterPreset.Essentials:
+                    include.UnionWith(new[] { "Scenes", "Prefabs", "Scripts", "Materials" });
+                    break;
+                case FilterPreset.ScenesAndScripts:
+                    include.UnionWith(new[] { "Scenes", "Scripts" });
+                    break;
+                case FilterPreset.Everything:
+                    foreach (var cat in _categories)
+                        include.Add(cat.Name);
+                    break;
+            }
+
+            foreach (var cat in _categories)
+            {
+                bool shouldSelect = include.Contains(cat.Name);
+                SetCategorySelected(cat, shouldSelect, fromPreset: true);
+            }
+
+            _activePreset = preset;
+        }
+
+        void SetCategorySelected(CategoryInfo cat, bool selected, bool fromPreset)
+        {
+            cat.Selected = selected;
+            foreach (int idx in cat.Indices)
+            {
+                if (idx >= 0 && idx < _selected.Count)
+                    _selected[idx] = selected;
+            }
+
+            if (!fromPreset)
+                _activePreset = null;
+        }
+
+        void LoadManifestIfNeeded(bool force = false)
+        {
+            if (_selectedVersion == null)
+                return;
+
+            if (!force && _entries.Count > 0)
+                return;
+
+            _entries.Clear();
+            _categories.Clear();
+            _selected.Clear();
+            _loadError = null;
+            _restoreCompleted = false;
+            _completionMessage = null;
+
+            try
+            {
+                string versionsRoot = Path.Combine(FileUtilEx.BackupRoot, "Versions");
+                string manifestPath = Path.Combine(versionsRoot, $"v{_selectedVersion.id:D3}", "manifest.json");
+                if (!File.Exists(manifestPath))
+                {
+                    _loadError = L.T("easy.restore.manifest.missing", "Manifest missing for this backup.");
+                    return;
+                }
+
+                var json = File.ReadAllText(manifestPath);
+                var manifest = JsonUtility.FromJson<BackupManifest>(json);
+                if (manifest?.entries == null)
+                {
+                    _loadError = L.T("easy.restore.manifest.invalid", "Manifest is empty.");
+                    return;
+                }
+
+                for (int i = 0; i < manifest.entries.Count; i++)
+                {
+                    var entry = manifest.entries[i];
+                    if (entry == null || string.IsNullOrEmpty(entry.relPath))
+                        continue;
+
+                    string rel = entry.relPath.Replace('\\', '/');
+                    string category = ResolveCategory(rel);
+                    var info = new EntryInfo
+                    {
+                        RelPath = rel,
+                        Size = Math.Max(0, entry.size),
+                        Category = category
+                    };
+                    int index = _entries.Count;
+                    _entries.Add(info);
+                    _selected.Add(false);
+
+                    var cat = _categories.FirstOrDefault(c => string.Equals(c.Name, category, StringComparison.OrdinalIgnoreCase));
+                    if (cat == null)
+                    {
+                        cat = new CategoryInfo { Name = category };
+                        _categories.Add(cat);
+                    }
+                    cat.Indices.Add(index);
+                    cat.TotalSize += info.Size;
+                }
+
+                _categories.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+                ApplyPreset(FilterPreset.Essentials);
+            }
+            catch (Exception ex)
+            {
+                _loadError = ex.Message;
+            }
+        }
+
+        static string ResolveCategory(string relPath)
+        {
+            string lower = relPath.ToLowerInvariant();
+            string ext = Path.GetExtension(lower);
+            if (string.IsNullOrEmpty(ext))
+            {
+                if (lower.Contains("/scenes")) return "Scenes";
+                if (lower.Contains("/scripts")) return "Scripts";
+                return "Other";
+            }
+
+            switch (ext)
+            {
+                case ".unity": return "Scenes";
+                case ".prefab": return "Prefabs";
+                case ".mat":
+                case ".material": return "Materials";
+                case ".cs":
+                case ".asmdef":
+                case ".asmref":
+                case ".uxml":
+                case ".ussp": return "Scripts";
+                case ".anim":
+                case ".controller":
+                case ".overridecontroller":
+                case ".playable": return "Animation";
+                case ".png":
+                case ".jpg":
+                case ".jpeg":
+                case ".tga":
+                case ".psd":
+                case ".tiff":
+                case ".exr":
+                case ".bmp": return "Textures";
+                case ".shader":
+                case ".cginc":
+                case ".compute":
+                case ".hlsl": return "Shaders";
+                case ".wav":
+                case ".mp3":
+                case ".ogg":
+                case ".aiff":
+                case ".aif":
+                case ".flac": return "Audio";
+                case ".asset":
+                case ".inputactions": return "Settings";
+                default:
+                    return "Other";
+            }
+        }
+
+        void ComputeSelectionStats(out int count, out long size)
+        {
+            count = 0;
+            size = 0;
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (!_selected[i])
+                    continue;
+                count++;
+                size += _entries[i].Size;
+            }
+        }
+
+        bool HasAnySelection()
+        {
+            for (int i = 0; i < _selected.Count; i++)
+            {
+                if (_selected[i])
+                    return true;
+            }
+            return false;
+        }
+
+        void PerformRestore()
+        {
+            if (_selectedVersion == null || !_selected.Any(s => s))
+                return;
+
+            _restoreInProgress = true;
+            try
+            {
+                string? snapshot = PrepareSnapshot();
+                if (string.IsNullOrEmpty(snapshot) || !Directory.Exists(snapshot))
+                {
+                    Banner.Draw(MessageType.Error, L.T("easy.restore.snapshot.missing", "Unable to prepare snapshot for this backup."));
+                    return;
+                }
+
+                if (_safetyBackup)
+                {
+                    if (!CreateSafetyBackup())
+                    {
+                        if (!EditorUtility.DisplayDialog(L.T("easy.restore.safety.fail.title", "Safety backup failed"), L.T("easy.restore.safety.fail.body", "Unable to create safety backup. Continue restore anyway?"), L.T("rp.yes", "Yes"), L.T("rp.no", "No")))
+                        {
+                            return;
+                        }
+                    }
+                }
+
+                string targetRoot = FileUtilEx.ProjectRoot;
+                int restored = 0;
+                for (int i = 0; i < _entries.Count; i++)
+                {
+                    if (!_selected[i])
+                        continue;
+
+                    var entry = _entries[i];
+                    string src = Path.Combine(snapshot, entry.RelPath.Replace('/', Path.DirectorySeparatorChar));
+                    string dst = Path.Combine(targetRoot, entry.RelPath.Replace('/', Path.DirectorySeparatorChar));
+                    try
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(dst));
+                        File.Copy(src, dst, true);
+                        restored++;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warn("RestoreEasyWizard: failed to copy " + entry.RelPath + " - " + ex.Message);
+                    }
+                }
+
+                AssetDatabase.Refresh();
+                _restoreCompleted = true;
+                _completionMessage = string.Format(L.T("easy.restore.done", "Restore completed. Files restored: {0}"), restored);
+            }
+            finally
+            {
+                _restoreInProgress = false;
+            }
+        }
+
+        string? PrepareSnapshot()
+        {
+            if (_selectedVersion == null)
+                return null;
+
+            if (!string.IsNullOrEmpty(_snapshotRoot) && Directory.Exists(_snapshotRoot))
+                return _snapshotRoot;
+
+            try
+            {
+                string? path = VersionRestoreService.PrepareSnapshot(_selectedVersion.id, forceRebuild: false);
+                _snapshotRoot = path;
+                return path;
+            }
+            catch (Exception ex)
+            {
+                _completionMessage = string.Format(L.T("easy.restore.snapshot.error", "Failed to prepare snapshot: {0}"), ex.Message);
+                Banner.Draw(MessageType.Error, _completionMessage);
+                return null;
+            }
+        }
+
+        bool CreateSafetyBackup()
+        {
+            try
+            {
+                string stamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
+                string safedir = Path.Combine(FileUtilEx.BackupRoot, "PreRestore", stamp);
+                foreach (var f in Directory.GetFiles(Path.Combine(FileUtilEx.ProjectRoot, "Assets"), "*", SearchOption.AllDirectories))
+                {
+                    string rel = FileUtilEx.MakeRelToProject(f).Replace("\\", "/");
+                    string dst = Path.Combine(safedir, rel);
+                    Directory.CreateDirectory(Path.GetDirectoryName(dst));
+                    File.Copy(f, dst, true);
+                }
+                Log.Info("Pre-restore backup created: " + safedir);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warn("RestoreEasyWizard safety backup failed: " + ex.Message);
+                return false;
+            }
+        }
+
+        static DateTime ParseCreatedUtc(VersionInfo info)
+        {
+            if (!string.IsNullOrEmpty(info.createdUtc) && DateTime.TryParse(info.createdUtc, null, System.Globalization.DateTimeStyles.RoundtripKind, out var c))
+                return c;
+            return info.timestamp;
+        }
+
+        static string FormatSize(long bytes)
+        {
+            if (bytes < 1024) return bytes + " B";
+            double kb = bytes / 1024.0;
+            if (kb < 1024) return kb.ToString("F1") + " KB";
+            double mb = kb / 1024.0;
+            if (mb < 1024) return mb.ToString("F1") + " MB";
+            double gb = mb / 1024.0;
+            return gb.ToString("F2") + " GB";
+        }
+
+        readonly struct GuiColorScope : IDisposable
+        {
+            readonly Color _prev;
+            public GuiColorScope(Color color)
+            {
+                _prev = GUI.color;
+                GUI.color = color;
+            }
+
+            public void Dispose()
+            {
+                GUI.color = _prev;
+            }
+        }
+    }
+}
+#endif

--- a/Editor/Windows/RestorePreviewWindow.cs
+++ b/Editor/Windows/RestorePreviewWindow.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 using AvatarSmartBackup.Localization;
+using AvatarSmartBackup.Shared;
+using AvatarSmartBackup.Config;
 
 namespace AvatarSmartBackup
 {
@@ -61,6 +63,8 @@ namespace AvatarSmartBackup
     string? _resolvedSnapshotRoot;
     string? _snapshotWarning;
     // (HashCache disabled fallback) – se HashCache.cs non ancora compilato nell'ambiente, usiamo MD5 diretto.
+    readonly ModernInfoBanner _modernInfoBanner = new ModernInfoBanner();
+    StatusBanner? _statusBanner;
 
     const string PREF_FOLD_SUMMARY = "ASB_Restore_Fold_Summary";
     const string PREF_FOLD_FILTERS = "ASB_Restore_Fold_Filters";
@@ -75,6 +79,8 @@ namespace AvatarSmartBackup
     const float SummaryBadgeWidth = 150f;
     static GUIStyle? _summaryBadgeLabelStyle;
     static GUIStyle? _summaryTypeLabelStyle;
+
+        StatusBanner SharedStatusBanner => _statusBanner ??= new StatusBanner(_modernInfoBanner);
 
         void OnEnable()
         {
@@ -469,7 +475,9 @@ namespace AvatarSmartBackup
         {
             EnsureSettingsLoaded();
 
-            if (_easyMode && (!_showNew || !_showChanged || !_showSame))
+            var layoutMode = _easyMode ? BackupLayoutSchema.LayoutMode.Easy : BackupLayoutSchema.LayoutMode.Advanced;
+
+            if (layoutMode == BackupLayoutSchema.LayoutMode.Easy && (!_showNew || !_showChanged || !_showSame))
             {
                 _showNew = _showChanged = _showSame = true;
                 MarkAllCategoryCachesDirty(true);
@@ -510,7 +518,7 @@ namespace AvatarSmartBackup
                     infoMsg += "\n" + string.Format(L.T("rp.info.changes", "Recorded changes: {0} (removed: {1})."), diffCount,removedCount);
                 if (!string.IsNullOrEmpty(_snapshotWarning))
                     infoMsg += "\n" + _snapshotWarning;
-                EditorGUILayout.HelpBox(infoMsg, MessageType.Info);
+                SharedStatusBanner.Draw(MessageType.Info, infoMsg, spacing: 4f);
             }
 
             if (_requireModeChoice)
@@ -522,15 +530,10 @@ namespace AvatarSmartBackup
             if (_isScanning)
             {
                 float p = _scanTotal > 0 ? (float)_scanProcessed / _scanTotal : 0f;
-                EditorGUILayout.HelpBox(string.Format(L.T("rp.scan.progress", "Scanning files... {0}/{1} ({2:0.0}%)"), _scanProcessed, _scanTotal, p*100f), MessageType.Info);
+                SharedStatusBanner.Draw(MessageType.Info, string.Format(L.T("rp.scan.progress", "Scanning files... {0}/{1} ({2:0.0}%)"), _scanProcessed, _scanTotal, p*100f), spacing: 4f);
                 Rect r = GUILayoutUtility.GetRect(4, 18);
                 EditorGUI.ProgressBar(r, p, L.T("rp.scan.bar", "Building diff"));
                 GUILayout.Space(4);
-            }
-
-            if (_easyMode && !_easyBannerDismissed)
-            {
-                DrawEasyModeBanner();
             }
 
             if (_filter != _lastFilter)
@@ -558,15 +561,74 @@ namespace AvatarSmartBackup
                 MarkAllCategoryCachesDirty(true);
             }
 
-            EditorGUILayout.HelpBox(_easyMode
-                ? L.T("rp.help.easy", "Pick the files you need. Summary, quick filters and the file list are below. The safety backup toggle stays at the bottom.")
-                : L.T("rp.help", "Choose what to restore. Expand sections: Summary, Filters, Selection, Files. The safety backup toggle is in the footer."), MessageType.Info);
+            DrawRestoreLayout(layoutMode);
 
-            // SUMMARY FOLDOUT (FIRST)
+            // Shortcuts: Invio = restore (context aware), Esc = cancel
+            if (Event.current.type == EventType.KeyDown)
+            {
+                if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
+                { DoRestore(); Event.current.Use(); }
+                else if (Event.current.keyCode == KeyCode.Escape) { Close(); Event.current.Use(); }
+            }
+        }
+
+        void DrawRestoreLayout(BackupLayoutSchema.LayoutMode mode)
+        {
+            foreach (var block in BackupLayoutSchema.RestorePreviewBlocks)
+            {
+                if (!block.Supports(mode))
+                    continue;
+
+                switch (block.Id)
+                {
+                    case BackupLayoutSchema.RestorePreviewBlock.EasyBanner:
+                        DrawEasyBannerIfNeeded();
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.HelperBanner:
+                        DrawHelperBanner(mode);
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.Summary:
+                        DrawSummary(mode);
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.Filters:
+                        DrawFiltersSection(mode);
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.Selection:
+                        DrawSelectionSection(mode);
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.Files:
+                        DrawFilesSection();
+                        break;
+                    case BackupLayoutSchema.RestorePreviewBlock.Footer:
+                        DrawFooter(mode);
+                        break;
+                }
+            }
+        }
+
+        void DrawEasyBannerIfNeeded()
+        {
+            if (_easyBannerDismissed)
+                return;
+            DrawEasyModeBanner();
+        }
+
+        void DrawHelperBanner(BackupLayoutSchema.LayoutMode mode)
+        {
+            SharedStatusBanner.Draw(MessageType.Info, mode == BackupLayoutSchema.LayoutMode.Easy
+                ? L.T("rp.help.easy", "Pick the files you need. Summary, quick filters and the file list are below. The safety backup toggle stays at the bottom.")
+                : L.T("rp.help", "Choose what to restore. Expand sections: Summary, Filters, Selection, Files. The safety backup toggle is in the footer."));
+        }
+
+        void DrawSummary(BackupLayoutSchema.LayoutMode mode)
+        {
             _foldSummary = EditorGUILayout.BeginFoldoutHeaderGroup(_foldSummary, L.T("rp.fold.summary", "Summary"));
             if (_foldSummary)
             {
-                int total = _diffInfos.Count; int news = _diffInfos.Count(d=>d.state==DiffState.New); int changed = _diffInfos.Count(d=>d.state==DiffState.Changed); int same = _diffInfos.Count(d=>d.state==DiffState.Same);
+                int total = _diffInfos.Count;
+                int news = _diffInfos.Count(d => d.state == DiffState.New);
+                int changed = _diffInfos.Count(d => d.state == DiffState.Changed);
+                int same = _diffInfos.Count(d => d.state == DiffState.Same);
                 if (_versionInfo != null)
                 {
                     DrawVersionTypeBadge();
@@ -586,29 +648,31 @@ namespace AvatarSmartBackup
                 }
                 EditorGUILayout.LabelField(string.Format(L.T("rp.stats", "Files: {0}   New: {1}   Changed: {2}   Same: {3}"), total, news, changed, same), EditorStyles.miniLabel);
                 EditorGUILayout.BeginHorizontal();
-                DrawBigStat(L.T("rp.stat.new", "NEW"), news.ToString(), new Color(0.40f,0.80f,0.45f,1f));
-                DrawBigStat(L.T("rp.stat.changed", "CHANGED"), changed.ToString(), new Color(0.95f,0.80f,0.35f,1f));
-                DrawBigStat(L.T("rp.stat.same", "SAME"), same.ToString(), new Color(0.55f,0.55f,0.55f,1f));
+                DrawBigStat(L.T("rp.stat.new", "NEW"), news.ToString(), new Color(0.40f, 0.80f, 0.45f, 1f));
+                DrawBigStat(L.T("rp.stat.changed", "CHANGED"), changed.ToString(), new Color(0.95f, 0.80f, 0.35f, 1f));
+                DrawBigStat(L.T("rp.stat.same", "SAME"), same.ToString(), new Color(0.55f, 0.55f, 0.55f, 1f));
                 GUILayout.FlexibleSpace();
-                if (!_easyMode && GUILayout.Button(new GUIContent(L.T("rp.restore.all", "Restore ALL"), L.T("rp.restore.all.tt", "Restore all files")), GUILayout.Width(120), GUILayout.Height(28)))
+                if (mode == BackupLayoutSchema.LayoutMode.Advanced && GUILayout.Button(new GUIContent(L.T("rp.restore.all", "Restore ALL"), L.T("rp.restore.all.tt", "Restore all files")), GUILayout.Width(120), GUILayout.Height(28)))
                 {
                     SelectAllInternal(true);
                     DoRestore();
                 }
                 EditorGUILayout.EndHorizontal();
-                if (!_easyMode && _extCounts.Count > 0)
+                if (mode == BackupLayoutSchema.LayoutMode.Advanced && _extCounts.Count > 0)
                 {
                     GUILayout.Space(4);
                     EditorGUILayout.LabelField(L.T("rp.top.extensions", "Top extensions"), EditorStyles.miniBoldLabel);
                     EditorGUILayout.BeginHorizontal();
                     EditorGUILayout.BeginVertical(GUILayout.MaxWidth(160));
-                    foreach (var kv in _extCounts.OrderByDescending(k=>k.Value).Take(6)) EditorGUILayout.LabelField($"{kv.Key} {kv.Value}", EditorStyles.miniLabel);
+                    foreach (var kv in _extCounts.OrderByDescending(k => k.Value).Take(6))
+                        EditorGUILayout.LabelField($"{kv.Key} {kv.Value}", EditorStyles.miniLabel);
                     EditorGUILayout.EndVertical();
                     if (_assetTypeCounts.Count > 0)
                     {
                         EditorGUILayout.BeginVertical(GUILayout.MaxWidth(180));
                         EditorGUILayout.LabelField(L.T("rp.asset.types", ".asset types"), EditorStyles.miniBoldLabel);
-                        foreach (var kv in _assetTypeCounts.OrderByDescending(k=>k.Value).Take(6)) EditorGUILayout.LabelField($"{kv.Key} {kv.Value}", EditorStyles.miniLabel);
+                        foreach (var kv in _assetTypeCounts.OrderByDescending(k => k.Value).Take(6))
+                            EditorGUILayout.LabelField($"{kv.Key} {kv.Value}", EditorStyles.miniLabel);
                         EditorGUILayout.EndVertical();
                     }
                     GUILayout.FlexibleSpace();
@@ -616,33 +680,36 @@ namespace AvatarSmartBackup
                 }
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
+        }
 
-            // FILTERS FOLDOUT
+        void DrawFiltersSection(BackupLayoutSchema.LayoutMode mode)
+        {
             _foldFilters = EditorGUILayout.BeginFoldoutHeaderGroup(_foldFilters, L.T("rp.fold.filters", "Filters"));
             if (_foldFilters)
             {
-                if (_easyMode)
+                if (mode == BackupLayoutSchema.LayoutMode.Easy)
                     DrawEasyFilters();
                 else
                     DrawAdvancedFilters();
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
+        }
 
-            // SELECTION TOOLS FOLDOUT
+        void DrawSelectionSection(BackupLayoutSchema.LayoutMode mode)
+        {
             _foldSelection = EditorGUILayout.BeginFoldoutHeaderGroup(_foldSelection, L.T("rp.fold.selection", "Selection"));
             if (_foldSelection)
             {
-                if (_easyMode)
+                if (mode == BackupLayoutSchema.LayoutMode.Easy)
                     DrawEasySelectionTools();
                 else
                     DrawAdvancedSelectionTools();
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
+        }
 
-
-            // (old filters/selection sections removed above)
-
-            // FILES FOLDOUT
+        void DrawFilesSection()
+        {
             _foldFiles = EditorGUILayout.BeginFoldoutHeaderGroup(_foldFiles, "Files");
             if (_foldFiles)
             {
@@ -650,22 +717,26 @@ namespace AvatarSmartBackup
                 bool anyGroupVisible = false;
                 foreach (var cat in _categoriesOrdered)
                 {
-                    if (!_categoryCache.TryGetValue(cat.name, out var cache)) { cache = new CategoryViewCache(); _categoryCache[cat.name]=cache; cache.dirty=true; }
+                    if (!_categoryCache.TryGetValue(cat.name, out var cache))
+                    {
+                        cache = new CategoryViewCache();
+                        _categoryCache[cat.name] = cache;
+                        cache.dirty = true;
+                    }
                     if (cache.dirty)
                     {
                         RefreshCategoryView(cat, cache);
                     }
-                    if (cache.totalVisible==0) continue;
+                    if (cache.totalVisible == 0) continue;
                     anyGroupVisible = true;
 
                     Rect rowRect = EditorGUILayout.BeginHorizontal();
-                    // Tri-state per categoria
-                    bool prevMixed = cache.selectedCount>0 && cache.selectedCount<cache.totalVisible;
+                    bool prevMixed = cache.selectedCount > 0 && cache.selectedCount < cache.totalVisible;
                     EditorGUI.showMixedValue = prevMixed;
-                    bool catToggleState = cache.selectedCount>0;
+                    bool catToggleState = cache.selectedCount > 0;
                     bool newToggleState = EditorGUILayout.Toggle(catToggleState, GUILayout.Width(16));
                     EditorGUI.showMixedValue = false;
-                    if (newToggleState != catToggleState || (prevMixed && newToggleState==catToggleState))
+                    if (newToggleState != catToggleState || (prevMixed && newToggleState == catToggleState))
                     {
                         bool target = !(cache.selectedCount == cache.totalVisible);
                         foreach (var vi in cache.visibleIndices) _selected[vi] = target;
@@ -673,16 +744,17 @@ namespace AvatarSmartBackup
                         RefreshCategoryView(cat, cache);
                     }
                     string badge = string.Empty;
-                    if (cache.newCount>0) badge += $" <color=#41CC55>+{cache.newCount}</color>";
-                    if (cache.changedCount>0) badge += $" <color=#E6C24A>Δ{cache.changedCount}</color>";
-                    GUIStyle foldStyle = new GUIStyle(EditorStyles.foldoutHeader){richText=true};
-                    // Simula foldout full-row cliccabile
+                    if (cache.newCount > 0) badge += $" <color=#41CC55>+{cache.newCount}</color>";
+                    if (cache.changedCount > 0) badge += $" <color=#E6C24A>Δ{cache.changedCount}</color>";
+                    GUIStyle foldStyle = new GUIStyle(EditorStyles.foldoutHeader) { richText = true };
                     Rect foldLabelRect = GUILayoutUtility.GetRect(new GUIContent("tmp"), foldStyle, GUILayout.ExpandWidth(true));
                     string foldText = $"{cat.name} ({cache.selectedCount}/{cache.totalVisible}){badge}";
                     cat.expanded = EditorGUI.Foldout(foldLabelRect, cat.expanded, foldText, true, foldStyle);
-                    // Row click (escluso toggle): se clic dentro label rect e non sul toggle, toggla
-                    if (Event.current.type==EventType.MouseDown && rowRect.Contains(Event.current.mousePosition) && !new Rect(rowRect.x,rowRect.y,16,rowRect.height).Contains(Event.current.mousePosition))
-                    { cat.expanded = !cat.expanded; Event.current.Use(); }
+                    if (Event.current.type == EventType.MouseDown && rowRect.Contains(Event.current.mousePosition) && !new Rect(rowRect.x, rowRect.y, 16, rowRect.height).Contains(Event.current.mousePosition))
+                    {
+                        cat.expanded = !cat.expanded;
+                        Event.current.Use();
+                    }
                     GUILayout.FlexibleSpace();
                     EditorGUILayout.EndHorizontal();
                     if (cat.expanded)
@@ -691,7 +763,7 @@ namespace AvatarSmartBackup
                         foreach (var idxRaw in cache.visibleIndices)
                         {
                             var di = _diffInfos[idxRaw];
-                            if (!_fileIndex.TryGetValue(di.rel, out int realIdx)) continue; // should exist
+                            if (!_fileIndex.TryGetValue(di.rel, out int realIdx)) continue;
                             EditorGUILayout.BeginHorizontal();
                             bool prevSelected = _selected[realIdx];
                             bool newSelected = EditorGUILayout.Toggle(prevSelected, GUILayout.Width(16));
@@ -700,9 +772,9 @@ namespace AvatarSmartBackup
                                 _selected[realIdx] = newSelected;
                                 recalcAfterLoop = true;
                             }
-                            using (new GuiColorScope(di.state == DiffState.New ? new Color(0.55f,0.85f,0.55f,1f)
-                                : di.state == DiffState.Changed ? new Color(0.95f,0.85f,0.55f,1f)
-                                : di.state == DiffState.Same ? new Color(0.8f,0.8f,0.8f,0.8f)
+                            using (new GuiColorScope(di.state == DiffState.New ? new Color(0.55f, 0.85f, 0.55f, 1f)
+                                : di.state == DiffState.Changed ? new Color(0.95f, 0.85f, 0.55f, 1f)
+                                : di.state == DiffState.Same ? new Color(0.8f, 0.8f, 0.8f, 0.8f)
                                 : GUI.color))
                             {
                                 string labelSource = _showNamesOnly ? Path.GetFileName(di.rel) : di.rel;
@@ -737,31 +809,29 @@ namespace AvatarSmartBackup
                 }
                 EditorGUILayout.EndScrollView();
                 ComputeVisibleTotals(out int totalVisible, out int totalSelectedVisible);
-                EditorGUILayout.LabelField(string.Format(L.T("rp.items.selected", "Items: {0}    Selected: {1}"), totalVisible,totalSelectedVisible), EditorStyles.miniLabel);
-                if (!anyGroupVisible || totalVisible==0) EditorGUILayout.HelpBox(L.T("rp.no.files", "No files match the current filters."), MessageType.Info);
+                EditorGUILayout.LabelField(string.Format(L.T("rp.items.selected", "Items: {0}    Selected: {1}"), totalVisible, totalSelectedVisible), EditorStyles.miniLabel);
+                if (!anyGroupVisible || totalVisible == 0)
+                {
+                    SharedStatusBanner.Draw(MessageType.Info, L.T("rp.no.files", "No files match the current filters."));
+                }
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
+        }
 
-
-            // Footer
+        void DrawFooter(BackupLayoutSchema.LayoutMode mode)
+        {
             GUILayout.Space(4);
             EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
             if (GUILayout.Button(L.T("rp.cancel", "Cancel"), GUILayout.Width(90))) { Close(); }
             GUILayout.FlexibleSpace();
             _backupBefore = GUILayout.Toggle(_backupBefore, new GUIContent(L.T("rp.safety", "Safety Backup"), L.T("rp.safety.tt", "Make a safety copy before restoring")), GUILayout.Width(140));
-            int selectedCount = 0; long selectedSize = 0; for (int i=0;i<_diffInfos.Count;i++) if (_selected[i]) { selectedCount++; selectedSize += _diffInfos[i].size; }
+            int selectedCount = 0;
+            long selectedSize = 0;
+            for (int i = 0; i < _diffInfos.Count; i++) if (_selected[i]) { selectedCount++; selectedSize += _diffInfos[i].size; }
             GUILayout.Label(string.Format(L.T("rp.selected.summary", "Selected: {0} files ({1})"), selectedCount, FormatSize(selectedSize)), EditorStyles.miniLabel);
-            if (!_easyMode && GUILayout.Button(new GUIContent(L.T("rp.restore.copy", "Restore as Copy"), L.T("rp.restore.copy.tt", "Copy selected files to another folder")), GUILayout.Width(150), GUILayout.Height(24))) { DoRestore(true); }
+            if (mode == BackupLayoutSchema.LayoutMode.Advanced && GUILayout.Button(new GUIContent(L.T("rp.restore.copy", "Restore as Copy"), L.T("rp.restore.copy.tt", "Copy selected files to another folder")), GUILayout.Width(150), GUILayout.Height(24))) { DoRestore(true); }
             if (GUILayout.Button(new GUIContent(L.T("rp.restore.selected", "Restore Selected"), L.T("rp.restore.selected.tt", "Restore selected files")), GUILayout.Width(140), GUILayout.Height(24))) { DoRestore(); }
             EditorGUILayout.EndHorizontal();
-
-            // Shortcuts: Invio = restore (context aware), Esc = cancel
-            if (Event.current.type == EventType.KeyDown)
-            {
-                if (Event.current.keyCode == KeyCode.Return || Event.current.keyCode == KeyCode.KeypadEnter)
-                { DoRestore(); Event.current.Use(); }
-                else if (Event.current.keyCode == KeyCode.Escape) { Close(); Event.current.Use(); }
-            }
         }
 
         void DrawEasyModeBanner()
@@ -785,7 +855,7 @@ namespace AvatarSmartBackup
         void DrawModeChoiceGate()
         {
             EditorGUILayout.Space();
-            EditorGUILayout.HelpBox(L.T("rp.mode.gate.body", "Choose how you want to restore files before continuing."), MessageType.Info);
+            SharedStatusBanner.Draw(MessageType.Info, L.T("rp.mode.gate.body", "Choose how you want to restore files before continuing."));
             EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button(L.T("ui.mode.easy", "Easy"), GUILayout.Width(120), GUILayout.Height(28)))
             {
@@ -847,7 +917,7 @@ namespace AvatarSmartBackup
 
         void DrawEasyFilters()
         {
-            EditorGUILayout.HelpBox(L.T("rp.easy.filters.note", "Quick filter only. Advanced toggles live in Advanced mode."), MessageType.Info);
+            SharedStatusBanner.Draw(MessageType.Info, L.T("rp.easy.filters.note", "Quick filter only. Advanced toggles live in Advanced mode."));
             EditorGUILayout.BeginHorizontal();
             bool newHideMeta = EditorGUILayout.ToggleLeft(new GUIContent(L.T("rp.filter.hideMeta", "Hide .meta"), L.T("rp.filter.hideMeta.tt", "Hide .meta")), _hideMeta, GUILayout.Width(160));
             if (newHideMeta != _hideMeta)
@@ -904,7 +974,7 @@ namespace AvatarSmartBackup
 
         void DrawEasySelectionTools()
         {
-            EditorGUILayout.HelpBox(L.T("rp.easy.selection.note", "Quick actions shown. Advanced batch tools are available in Advanced mode."), MessageType.Info);
+            SharedStatusBanner.Draw(MessageType.Info, L.T("rp.easy.selection.note", "Quick actions shown. Advanced batch tools are available in Advanced mode."));
             EditorGUILayout.BeginHorizontal();
             if (GUILayout.Button(L.T("rp.select.all", "Select All"), GUILayout.Width(90))) { SelectAllInternal(true); }
             if (GUILayout.Button(L.T("rp.deselect.all", "Deselect All"), GUILayout.Width(110))) { SelectAllInternal(false); }

--- a/Editor/Windows/Shared/SchedulerSection.cs
+++ b/Editor/Windows/Shared/SchedulerSection.cs
@@ -1,0 +1,147 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine;
+using AvatarSmartBackup.Backup;
+
+namespace AvatarSmartBackup.Shared
+{
+    internal sealed class SchedulerSection
+    {
+        readonly BackupWindowContext _context;
+        readonly StatusBanner _statusBanner;
+
+        public SchedulerSection(BackupWindowContext context, StatusBanner statusBanner)
+        {
+            _context = context;
+            _statusBanner = statusBanner;
+        }
+
+        public void Draw()
+        {
+            _context.RecordLayoutMarker("SchedulerSection");
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.autobackups.title", "Automatic Backups"), EditorStyles.boldLabel);
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            bool running = Session.IsRunning;
+            Color prev = GUI.backgroundColor;
+            GUI.backgroundColor = running ? new Color(0.25f, 0.55f, 0.25f, 1f) : new Color(0.45f, 0.2f, 0.2f, 1f);
+            if (GUILayout.Button(new GUIContent(running ? AvatarSmartBackup.Localization.L.T("ui.autobackups.on", "Automatic Backups: ON") : AvatarSmartBackup.Localization.L.T("ui.autobackups.off", "Automatic Backups: OFF"), AvatarSmartBackup.Localization.L.T("ui.autobackups.toggle.tt", "Toggle background backup scheduler")), GUILayout.Width(220), GUILayout.Height(30)))
+            {
+                _context.ToggleScheduler();
+            }
+            GUI.backgroundColor = prev;
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+            EditorGUILayout.Space(2);
+            {
+                var nextLabel = AvatarSmartBackup.Localization.L.T("ui.autobackups.next", "Next");
+                var lastLabel = AvatarSmartBackup.Localization.L.T("ui.autobackups.last", "Last");
+                var never = AvatarSmartBackup.Localization.L.T("ui.never", "never");
+                var nextStr = Session.NextRunUtc?.ToLocalTime().ToString("HH:mm:ss") ?? "--";
+                var lastStr = Session.LastBackupUtc?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? never;
+                EditorGUILayout.LabelField($"{nextLabel}: {nextStr}    {lastLabel}: {lastStr}");
+            }
+            DrawDiskStatusRow();
+            if (_context.Settings.filtersDirty && _context.Settings.easyMode)
+            {
+                _statusBanner.Draw(MessageType.Info, AvatarSmartBackup.Localization.L.T("ui.filters.pending", "Filter changes pending. The next backup will create a full checkpoint to apply the new scope."));
+            }
+            if (_context.Settings.AdvancedMode)
+            {
+                EditorGUILayout.Space(4);
+                DrawIntervalControls();
+                int effCopy = BackupManager.EffectiveCopyMBps(_context.Settings);
+                if (_context.Settings.lastBackupBytes > 0 && effCopy > 0)
+                {
+                    double secNeeded = _context.Settings.lastBackupBytes / (effCopy * 1024.0 * 1024.0);
+                    double intervalSeconds = _context.Settings.intervalInSeconds ? _context.Settings.intervalMinutes : _context.Settings.intervalMinutes * 60.0;
+                    if (secNeeded > intervalSeconds)
+                    {
+                        double minutesNeeded = secNeeded / 60.0;
+                        double mb = _context.Settings.lastBackupBytes / (1024.0 * 1024.0);
+                        _statusBanner.Draw(MessageType.Warning, AvatarSmartBackup.Localization.L.T("warn.backup.speed", "At {0} MB/s, backing up {1:0.0} MB takes ~{2:0.0} min, exceeding the interval.", effCopy, mb, minutesNeeded));
+                    }
+                }
+            }
+            else
+            {
+                EditorGUILayout.Space(4);
+                DrawIntervalControls();
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        void DrawDiskStatusRow()
+        {
+            var report = DiskSpaceMonitor.LastReport;
+            if (report.Status == DiskSpaceStatus.Unknown)
+                return;
+
+            var snapshot = report.Snapshot;
+            if (snapshot.totalBytes <= 0)
+                return;
+
+            string summary = $"Disk free: {DiskSpaceMonitor.FormatBytes(snapshot.freeBytes)} / {DiskSpaceMonitor.FormatBytes(snapshot.totalBytes)}";
+            summary += $" • Backups: {DiskSpaceMonitor.FormatBytes(snapshot.backupSizeBytes)}";
+            if (report.RequiredBytes > 0 && report.Stage != DiskSpaceStage.PostBackup)
+            {
+                summary += $" • Next estimate: {DiskSpaceMonitor.FormatBytes(report.RequiredBytes)}";
+            }
+
+            MessageType type = report.Status switch
+            {
+                DiskSpaceStatus.Warning => MessageType.Warning,
+                DiskSpaceStatus.Critical => MessageType.Error,
+                DiskSpaceStatus.Error => MessageType.Warning,
+                _ => MessageType.Info
+            };
+
+            _statusBanner.Draw(type, summary);
+        }
+
+        void DrawIntervalControls()
+        {
+            EditorGUILayout.BeginHorizontal();
+            bool changed = false;
+            string[] unitOptions = { AvatarSmartBackup.Localization.L.T("ui.interval.min", "min"), AvatarSmartBackup.Localization.L.T("ui.interval.sec", "sec") };
+            int currentUnitIndex = _context.Settings.intervalInSeconds ? 1 : 0;
+            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.interval.label", "Interval"), GUILayout.Width(60));
+            int maxValue = _context.Settings.intervalInSeconds ? 3600 : 240;
+            int newInterval = Mathf.Clamp(EditorGUILayout.IntField(_context.Settings.intervalMinutes, GUILayout.Width(70)), 1, maxValue);
+            if (newInterval != _context.Settings.intervalMinutes)
+            {
+                _context.Settings.intervalMinutes = newInterval;
+                changed = true;
+            }
+            int newUnitIndex = EditorGUILayout.Popup(currentUnitIndex, unitOptions, GUILayout.Width(50));
+            if (newUnitIndex != currentUnitIndex)
+            {
+                if (newUnitIndex == 1 && !_context.Settings.intervalInSeconds)
+                {
+                    _context.Settings.intervalMinutes = Mathf.Max(1, _context.Settings.intervalMinutes * 60);
+                    changed = true;
+                }
+                else if (newUnitIndex == 0 && _context.Settings.intervalInSeconds)
+                {
+                    _context.Settings.intervalMinutes = Mathf.Max(1, Mathf.RoundToInt(_context.Settings.intervalMinutes / 60f));
+                    changed = true;
+                }
+                _context.Settings.intervalInSeconds = (newUnitIndex == 1);
+                changed = true;
+            }
+            EditorGUILayout.EndHorizontal();
+            if (changed)
+            {
+                TimerService.InvalidateSettingsCache();
+                if (Session.IsRunning)
+                {
+                    TimerService.ScheduleNextRun(_context.Settings);
+                }
+                _context.RequestRepaint();
+            }
+        }
+    }
+}
+#endif

--- a/Editor/Windows/Shared/StatusBanner.cs
+++ b/Editor/Windows/Shared/StatusBanner.cs
@@ -1,0 +1,41 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using AvatarSmartBackup;
+
+namespace AvatarSmartBackup.Shared
+{
+    internal sealed class StatusBanner
+    {
+        readonly ModernInfoBanner _banner;
+
+        public StatusBanner(ModernInfoBanner banner)
+        {
+            _banner = banner;
+        }
+
+        public void Draw(MessageType type, string content, string? title = null, Texture? icon = null, float spacing = 2f)
+        {
+            if (string.IsNullOrEmpty(content))
+                return;
+
+            if (icon != null)
+            {
+                using (_banner.Scope(type, content, title, icon))
+                {
+                    if (spacing > 0f)
+                        GUILayout.Space(spacing);
+                }
+            }
+            else
+            {
+                using (_banner.Scope(type, content, title))
+                {
+                    if (spacing > 0f)
+                        GUILayout.Space(spacing);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Editor/Windows/Shared/VersionsCard.cs
+++ b/Editor/Windows/Shared/VersionsCard.cs
@@ -1,0 +1,50 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using AvatarSmartBackup.Backup;
+
+namespace AvatarSmartBackup.Shared
+{
+    internal sealed class VersionsCard
+    {
+        readonly BackupWindowContext _context;
+
+        public VersionsCard(BackupWindowContext context)
+        {
+            _context = context;
+        }
+
+        public void Draw()
+        {
+            _context.RecordLayoutMarker("VersionsOverview");
+            EditorGUILayout.BeginVertical("box");
+            EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.latest.title", "Latest Version"), EditorStyles.boldLabel);
+            _context.EnsureVersionsCache();
+            var latest = _context.GetLatestVersionCached();
+            if (latest != null)
+            {
+                EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.latest.label", "Latest Version:"), EditorStyles.miniBoldLabel);
+                string desc = _context.SanitizeInlineLabel(latest.description, AvatarSmartBackup.Localization.L.T("ui.overview.noDescription", "(no description)"));
+                EditorGUILayout.LabelField($"# {latest.id}  {desc}", EditorStyles.miniLabel);
+                var created = _context.ParseCreatedUtc(latest);
+                if (created != DateTime.MinValue)
+                    EditorGUILayout.LabelField($"{AvatarSmartBackup.Localization.L.T("ui.overview.created", "Created:")} {created:yyyy-MM-dd HH:mm:ss}", EditorStyles.miniLabel);
+                {
+                    var filesLbl = AvatarSmartBackup.Localization.L.T("ui.overview.filesSize", "Files");
+                    var sizeLbl = AvatarSmartBackup.Localization.L.T("ui.overview.size", "Size");
+                    EditorGUILayout.LabelField($"{filesLbl}: {latest.fileCount}  {sizeLbl}: {_context.FormatSize(latest.totalSizeBytes)}", EditorStyles.miniLabel);
+                }
+                if (GUILayout.Button(new GUIContent(AvatarSmartBackup.Localization.L.T("ui.overview.gotoVersions", "Go to Versions"), AvatarSmartBackup.Localization.L.T("tt.overview.gotoVersions", "Open Versions tab")), GUILayout.Width(140)))
+                {
+                    _context.Settings._activeTab = 1;
+                }
+            }
+            else
+            {
+                EditorGUILayout.LabelField(AvatarSmartBackup.Localization.L.T("ui.overview.none", "No versions available"), EditorStyles.miniLabel);
+            }
+            EditorGUILayout.EndVertical();
+        }
+    }
+}
+#endif

--- a/tests/AvatarSmartBackups.Tests/Editor/BackupWindowSnapshotTests.cs
+++ b/tests/AvatarSmartBackups.Tests/Editor/BackupWindowSnapshotTests.cs
@@ -64,7 +64,9 @@ namespace AvatarSmartBackups.Tests.Editor
                 Render(window);
 
                 var markers = context.LayoutMarkers.ToArray();
-                CollectionAssert.IsSupersetOf(markers, new[] { "ModeSelector", "SchedulerSection", "PrimaryActions", "VersionsOverview", "EasyFooter" });
+                CollectionAssert.IsSupersetOf(markers, new[] { "ModeSelector", "ModeSync", "EasyDashboard", "BodySpacing" });
+                Assert.IsTrue(markers.Any(m => m.StartsWith("EasyDashboard.", StringComparison.Ordinal)), "Easy dashboard should record a responsive snapshot marker.");
+                Assert.IsFalse(markers.Contains("SchedulerSection"), "Easy mode should not render the advanced scheduler section.");
                 Assert.IsFalse(markers.Contains("AdvancedOverview"), "Easy mode should not render advanced overview.");
             }
             finally


### PR DESCRIPTION
## Summary
- introduce the RestoreEasyWizard guided flow with step indicators, filter presets, and persistent selections across the backup, content, and confirmation steps
- offer preset filter shortcuts, category toggles, and advanced restore escalation from the wizard while surfacing completion feedback through shared status banners
- route easy-mode restore requests from the backup window context to the new wizard, keeping the advanced preview window for non-easy sessions

## Testing
- not run (Unity editor UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cdb6b9c29883228b49c0a4ac94d372